### PR TITLE
feat: update agkan-add to use --priority flag instead of meta set

### DIFF
--- a/.claude/skills/agkan-add/SKILL.md
+++ b/.claude/skills/agkan-add/SKILL.md
@@ -48,13 +48,19 @@ Gather the following from the user. Fields marked optional can be skipped if not
 ### 2. Create the Task
 
 ```bash
-agkan task add "<title>" "<body>"
+agkan task add "<title>" "<body>" --priority <value>
 ```
 
 If no body is provided:
 
 ```bash
-agkan task add "<title>"
+agkan task add "<title>" --priority <value>
+```
+
+If priority is `medium` (the default), the `--priority` flag can be omitted:
+
+```bash
+agkan task add "<title>" "<body>"
 ```
 
 Note the task ID returned from the command output.
@@ -67,21 +73,13 @@ For each tag:
 agkan tag attach <task-id> <tag-name>
 ```
 
-### 4. Set Priority (if not medium)
-
-```bash
-agkan task meta set <task-id> priority <value>
-```
-
-Skip this step if priority is `medium` (the default).
-
-### 5. Set Parent Task (if applicable)
+### 4. Set Parent Task (if applicable)
 
 ```bash
 agkan task update-parent <task-id> <parent-id>
 ```
 
-### 6. Show Summary
+### 5. Show Summary
 
 Retrieve and display the created task:
 


### PR DESCRIPTION
## 概要

agkan v2.4.0 で利用可能になった `--priority` フラグを使用するよう agkan-add スキルを更新。

## 変更内容

- ステップ2の `agkan task add` コマンドに `--priority <value>` フラグを追加
- ステップ4（Set Priority）を削除（`agkan task meta set` による別途設定が不要になったため）
- ステップ5・6 → ステップ4・5 に番号を繰り上げ

## 関連タスク

Task #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)