### PR TITLE
fix: update priority setting to use --priority flag in agkan-planning-subtask

### DIFF
--- a/.claude/skills/agkan-planning-subtask/SKILL.md
+++ b/.claude/skills/agkan-planning-subtask/SKILL.md
@@ -67,8 +67,7 @@ Move to Ready if **all** of the following conditions are met:
 When moving a task to Ready, also set the priority at this point:
 
 ```bash
-agkan task update <id> status ready
-agkan task meta set <id> priority <value>
+agkan task update <id> --status ready --priority <value>
 ```
 
 Priority values: `critical` / `high` / `medium` / `low`


### PR DESCRIPTION
## Summary

- Updated step 3 of `agkan-planning-subtask/SKILL.md`
- Consolidated two commands (`agkan task update <id> status ready` + `agkan task meta set <id> priority <value>`) into a single command: `agkan task update <id> --status ready --priority <value>`
- Updated to use the `--priority` flag introduced in agkan v2.4.0

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)