### PR TITLE
feat: update agkan-add to use --priority flag for task creation

### DIFF
--- a/.claude/skills/agkan-add/SKILL.md
+++ b/.claude/skills/agkan-add/SKILL.md
@@ -48,12 +48,19 @@ Gather the following from the user. Fields marked optional can be skipped if not
 ### 2. Create the Task
 
 ```bash
-agkan task add "<title>" "<body>"
+agkan task add "<title>" "<body>" --priority <value>
 ```
 
 If no body is provided:
 
 ```bash
+agkan task add "<title>" --priority <value>
+```
+
+If priority is `medium` (the default), the `--priority` flag can be omitted:
+
+```bash
+agkan task add "<title>" "<body>"
 agkan task add "<title>"
 ```
 
@@ -79,21 +86,13 @@ For each tag:
 agkan tag attach <task-id> <tag-name>
 ```
 
-### 4. Set Priority (if not medium)
-
-```bash
-agkan task meta set <task-id> priority <value>
-```
-
-Skip this step if priority is `medium` (the default).
-
-### 5. Set Parent Task (if applicable)
+### 4. Set Parent Task (if applicable)
 
 ```bash
 agkan task update-parent <task-id> <parent-id>
 ```
 
-### 6. Show Summary
+### 5. Show Summary
 
 Retrieve and display the created task:
 

--- a/skills/agkan-add/SKILL.md
+++ b/skills/agkan-add/SKILL.md
@@ -48,12 +48,19 @@ Gather the following from the user. Fields marked optional can be skipped if not
 ### 2. Create the Task
 
 ```bash
-agkan task add "<title>" "<body>"
+agkan task add "<title>" "<body>" --priority <value>
 ```
 
 If no body is provided:
 
 ```bash
+agkan task add "<title>" --priority <value>
+```
+
+If priority is `medium` (the default), the `--priority` flag can be omitted:
+
+```bash
+agkan task add "<title>" "<body>"
 agkan task add "<title>"
 ```
 
@@ -79,21 +86,13 @@ For each tag:
 agkan tag attach <task-id> <tag-name>
 ```
 
-### 4. Set Priority (if not medium)
-
-```bash
-agkan task meta set <task-id> priority <value>
-```
-
-Skip this step if priority is `medium` (the default).
-
-### 5. Set Parent Task (if applicable)
+### 4. Set Parent Task (if applicable)
 
 ```bash
 agkan task update-parent <task-id> <parent-id>
 ```
 
-### 6. Show Summary
+### 5. Show Summary
 
 Retrieve and display the created task:
 


### PR DESCRIPTION
## Summary

- Replace `agkan task meta set <task-id> priority <value>` with `--priority` flag in `agkan task add` command
- Removes the separate "Set Priority" step (step 4), integrating priority into task creation
- Renumbered subsequent steps accordingly (5→4 Set Parent Task, 6→5 Show Summary)
- Follows agkan 2.4.0+ API pattern for more efficient task creation

## Test plan

- [ ] Verify agkan-add skill creates tasks with correct priority using `--priority` flag
- [ ] Verify that omitting `--priority` still defaults to `medium`
- [ ] Confirm no separate `agkan task meta set` call is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)