### PR TITLE
docs: add blocker check command to agkan-planning-subtask

### DIFF
--- a/.claude/skills/agkan-planning-subtask/SKILL.md
+++ b/.claude/skills/agkan-planning-subtask/SKILL.md
@@ -64,6 +64,14 @@ Move to Ready if **all** of the following conditions are met:
 - Scope that can be implemented as a single PR
 - Implementation approach is clear
 
+Before moving to Ready, verify there are no blocking tasks:
+
+```bash
+agkan task block list <id> --json
+```
+
+If blockers exist, do not move to Ready. Keep in Backlog and apply the `will-do-later` tag (see Step 4).
+
 When moving a task to Ready, also set the priority at this point:
 
 ```bash

--- a/skills/agkan-planning-subtask/SKILL.md
+++ b/skills/agkan-planning-subtask/SKILL.md
@@ -64,6 +64,14 @@ Move to Ready if **all** of the following conditions are met:
 - Scope that can be implemented as a single PR
 - Implementation approach is clear
 
+Before moving to Ready, verify there are no blocking tasks:
+
+```bash
+agkan task block list <id> --json
+```
+
+If blockers exist, do not move to Ready. Keep in Backlog and apply the `will-do-later` tag (see Step 4).
+
 When moving a task to Ready, also set the priority at this point:
 
 ```bash


### PR DESCRIPTION
## Summary
- `agkan-planning-subtask/SKILL.md` の Step 3「Ready Status Movement Decision」に `agkan task block list <id> --json` コマンドの使用例を追記
- 「No blockers」条件の確認方法を具体的なコマンドで明示

## 背景
ブロッカー確認の条件は記載されていたが、具体的な確認コマンドが未記載だった。agkan-run/SKILL.md では既にブロッカーチェックが記載されており、agkan-planning-subtask でも同様に記載することで一貫性を持たせる。

## Test plan
- [ ] agkan-planning-subtask 実行時にブロッカーチェックコマンドが正しく使用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)