### PR TITLE
fix: replace git add -A with explicit file staging in execute-subtask-direct

### DIFF
--- a/.claude/skills/execute-subtask-direct/SKILL.md
+++ b/.claude/skills/execute-subtask-direct/SKILL.md
@@ -25,13 +25,15 @@ Refer to /key-guidelines during implementation to maintain code quality.
 
 ### 2. Commit
 
-Commit the changes.
+Stage files by specifying them explicitly. Do not use `git add -A` as it risks including unintended files such as `.env` or credentials.
 
 ```bash
-git add -A
+git add <file1> <file2> ...
 git commit -m "<commit message>"
 git push
 ```
+
+> **Note**: Do not use `git add -A` or `git add .`. Files containing `.env`, `credentials.*`, or secrets may be committed unintentionally.
 
 ### 3. Update task to done
 

--- a/skills/execute-subtask-direct/SKILL.md
+++ b/skills/execute-subtask-direct/SKILL.md
@@ -25,13 +25,15 @@ Refer to /key-guidelines during implementation to maintain code quality.
 
 ### 2. Commit
 
-Commit the changes.
+Stage files by specifying them explicitly. Do not use `git add -A` as it risks including unintended files such as `.env` or credentials.
 
 ```bash
-git add -A
+git add <file1> <file2> ...
 git commit -m "<commit message>"
 git push
 ```
+
+> **Note**: Do not use `git add -A` or `git add .`. Files containing `.env`, `credentials.*`, or secrets may be committed unintentionally.
 
 ### 3. Update task to done
 


### PR DESCRIPTION
## Summary

- Replace unsafe `git add -A` with explicit file specification (`git add <file1> <file2> ...`) in `execute-subtask-direct` skill
- Add a note warning against using `git add -A` or `git add .`
- Updated both `.claude/skills/execute-subtask-direct/SKILL.md` and `skills/execute-subtask-direct/SKILL.md`
- Now consistent with `agkan-subtask-direct` approach

Closes #61

## Test plan

- [ ] Verify `.claude/skills/execute-subtask-direct/SKILL.md` no longer contains `git add -A`
- [ ] Verify `skills/execute-subtask-direct/SKILL.md` no longer contains `git add -A`
- [ ] Confirm the updated instructions match `agkan-subtask-direct`'s commit section

🤖 Generated with [Claude Code](https://claude.com/claude-code)