### PR TITLE
docs: add skills-sync rules for .claude/skills and ./skills

### DIFF
--- a/.claude/rules/skills-sync.md
+++ b/.claude/rules/skills-sync.md
@@ -1,0 +1,19 @@
+# Skills Sync Rules
+
+## 対象ディレクトリ
+
+`.claude/skills` と `./skills` の2つのディレクトリは常に同期する。
+
+どちらか一方にスキルを追加・変更・削除した場合は、もう一方にも同じ変更を反映すること。
+
+## 例外
+
+`.claude/skills/release` ディレクトリは同期対象外とする。
+
+`./skills` 側には `release` ディレクトリを置かない。
+
+## 運用ルール
+
+- スキルの追加・変更・削除は必ず両方のディレクトリに反映する
+- `.claude/skills/release` のみ例外として片方（`.claude/skills`）にのみ存在する
+- 同期の確認は `ls .claude/skills` と `ls skills` を比較して行う（`release` を除く）


### PR DESCRIPTION
## Summary

- Create new `.claude/rules/skills-sync.md`
- Define operational rules to keep `.claude/skills` and `./skills` synchronized
- Clarify exception rules that exclude `.claude/skills/release` from synchronization

## Test plan

- [ ] Verify that `.claude/rules/skills-sync.md` exists
- [ ] Verify that the rules file contains descriptions of synchronized directories
- [ ] Verify that exception rules for the `release` directory are clearly stated

🤖 Generated with [Claude Code](https://claude.com/claude-code)