### PR TITLE
feat: include comments in agkan task get JSON schema

### DIFF
--- a/skills/agkan/SKILL.md
+++ b/skills/agkan/SKILL.md
@@ -242,6 +242,7 @@ agkan task list --status ready --json | jq '.tasks[].id'
   "blockedBy": [{ "id": 2, "title": "..." }],
   "blocking": [{ "id": 3, "title": "..." }],
   "tags": [{ "id": 1, "name": "bug" }],
+  "comments": [{ "id": 1, "task_id": 1, "author": "string | null", "content": "...", "created_at": "2026-01-01T00:00:00.000Z", "updated_at": "2026-01-01T00:00:00.000Z" }],
   "attachments": []
 }
 ```


### PR DESCRIPTION
## Summary

- Add `comments` field to the `agkan task get <id> --json` output schema in `skills/agkan/SKILL.md`
- The CLI already returns `comments` in the actual JSON output, but the documented schema was missing this field
- Comment schema includes: `id`, `task_id`, `author`, `content`, `created_at`, `updated_at`

## Test plan

- [ ] Verify `agkan task get <id> --json` returns a `comments` array in actual output
- [ ] Confirm the documented schema matches the actual CLI output structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)