### PR TITLE
docs(agkan): add task copy command documentation

### DIFF
--- a/skills/agkan/SKILL.md
+++ b/skills/agkan/SKILL.md
@@ -75,6 +75,12 @@ agkan task count --status ready --quiet  # Output numbers only
 agkan task update-parent <id> <parent_id>
 agkan task update-parent <id> null  # Remove parent
 
+# Copy a task
+agkan task copy <id>
+agkan task copy <id> --status ready    # Specify destination status (default: backlog)
+agkan task copy <id> --no-tags         # Do not copy tags
+agkan task copy <id> --json            # Output in JSON format
+
 # Delete task
 agkan task delete <id>
 


### PR DESCRIPTION
## Summary

Add documentation for the `agkan task copy` command to the agkan skill documentation.

## Related

- GitHub issue: gendosu/agkan-skills#35

## Changes

- Added `agkan task copy` command examples to `skills/agkan/SKILL.md`
- Includes usage with `--status`, `--no-tags`, and `--json` options
