### PR TITLE
docs(agkan): add task find --status option to SKILL.md

### DIFF
--- a/.claude/skills/agkan/SKILL.md
+++ b/.claude/skills/agkan/SKILL.md
@@ -54,6 +54,7 @@ agkan task get <id>
 # Search
 agkan task find "keyword"
 agkan task find "keyword" --all  # Include done/closed
+agkan task find "keyword" --status todo,in_progress   # Filter by status
 
 # Update (positional argument form - backward compatible)
 agkan task update <id> status in_progress

--- a/skills/agkan/SKILL.md
+++ b/skills/agkan/SKILL.md
@@ -54,6 +54,7 @@ agkan task get <id>
 # Search
 agkan task find "keyword"
 agkan task find "keyword" --all  # Include done/closed
+agkan task find "keyword" --status todo,in_progress   # Filter by status
 
 # Update (positional argument form - backward compatible)
 agkan task update <id> status in_progress


### PR DESCRIPTION
## Summary
- Add `--status` option documentation to the `agkan task find` Search section in SKILL.md
- Sync changes to both .claude/skills/agkan/SKILL.md and skills/agkan/SKILL.md

Closes #95