### PR TITLE
fix(agkan-planning-subtask): prevent moving tasks to ready when unresolved questions exist

### DIFF
--- a/.claude/skills/agkan-planning-subtask/SKILL.md
+++ b/.claude/skills/agkan-planning-subtask/SKILL.md
@@ -17,6 +17,10 @@ A sub-workflow that reviews a single Backlog task in agkan, makes decisions on d
 ### 1. Content Review, Supplementation, and Task List Creation
 
 - If task content is unclear, investigate and confirm details by examining the code
+- **If questions arise that cannot be resolved through code investigation alone:**
+  - Use `AskUserQuestion` to ask the user before proceeding
+  - Do NOT move to Ready until the question is resolved
+  - Record the question and the user's answer in the task body
 - Append the investigated content to the task description:
 
 ```bash
@@ -102,6 +106,7 @@ Move to Ready if **all** of the following conditions are met:
 
 - Scope that can be implemented as a single PR
 - Implementation approach is clear
+- No unresolved questions that require user input
 
 Blockers do **not** prevent moving to Ready. If planning is complete and the task would be executable once blockers are resolved, move it to Ready. The blocking relationships registered in Step 2 already capture the dependency — when the blocker task is done, this task can be picked up immediately.
 

--- a/skills/agkan-planning-subtask/SKILL.md
+++ b/skills/agkan-planning-subtask/SKILL.md
@@ -17,6 +17,10 @@ A sub-workflow that reviews a single Backlog task in agkan, makes decisions on d
 ### 1. Content Review, Supplementation, and Task List Creation
 
 - If task content is unclear, investigate and confirm details by examining the code
+- **If questions arise that cannot be resolved through code investigation alone:**
+  - Use `AskUserQuestion` to ask the user before proceeding
+  - Do NOT move to Ready until the question is resolved
+  - Record the question and the user's answer in the task body
 - Append the investigated content to the task description:
 
 ```bash
@@ -102,6 +106,7 @@ Move to Ready if **all** of the following conditions are met:
 
 - Scope that can be implemented as a single PR
 - Implementation approach is clear
+- No unresolved questions that require user input
 
 Blockers do **not** prevent moving to Ready. If planning is complete and the task would be executable once blockers are resolved, move it to Ready. The blocking relationships registered in Step 2 already capture the dependency — when the blocker task is done, this task can be picked up immediately.
 


### PR DESCRIPTION
## Summary

- Add `AskUserQuestion` flow to Step 1: when questions cannot be resolved through code investigation alone, ask the user before proceeding and do not move to Ready until resolved
- Add "No unresolved questions that require user input" as a required condition for Ready status movement in Step 4
- Apply both changes to both skill directories (`.claude/skills` and `./skills`) per skills sync rules

Fixes #101

## Test plan

- [ ] Run `agkan-planning` on a task with ambiguous requirements and verify the agent asks the user via `AskUserQuestion` before proceeding
- [ ] Verify tasks are not moved to `ready` when unresolved questions remain
- [ ] Verify tasks with clear requirements and no open questions still move to `ready` normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)