### PR TITLE
feat(agkan-run): treat will-do-later tasks in ready status as executable

### DIFF
--- a/.claude/skills/agkan-run-direct/SKILL.md
+++ b/.claude/skills/agkan-run-direct/SKILL.md
@@ -40,7 +40,7 @@ agkan task list --status ready --json
 Evaluate tasks using the following criteria in descending order and select the top one:
 
 **Skip tasks with `will-do-later` tag:**
-Tasks with the `will-do-later` tag are intentionally deferred tasks, so skip them. Only select tasks without the `will-do-later` tag.
+Tasks with the `will-do-later` tag are intentionally deferred tasks. Skip them **unless** they are in `ready` status — a task promoted to `ready` is executable regardless of the tag.
 
 **Priority (read from `metadata` field in the list JSON response):**
 ```

--- a/.claude/skills/agkan-run/SKILL.md
+++ b/.claude/skills/agkan-run/SKILL.md
@@ -48,7 +48,7 @@ agkan task list --status ready --json
 Evaluate tasks in descending order using the following criteria and select the top one:
 
 **Skip tasks with `will-do-later` tag:**
-Tasks with the `will-do-later` tag are intentionally postponed tasks, so skip them. Only select tasks that do not have the `will-do-later` tag.
+Tasks with the `will-do-later` tag are intentionally postponed tasks. Skip them **unless** they are in `ready` status — a task promoted to `ready` is executable regardless of the tag.
 
 **Priority (read from `metadata` field in the list JSON response):**
 ```

--- a/skills/agkan-run-direct/SKILL.md
+++ b/skills/agkan-run-direct/SKILL.md
@@ -40,7 +40,7 @@ agkan task list --status ready --json
 Evaluate tasks using the following criteria in descending order and select the top one:
 
 **Skip tasks with `will-do-later` tag:**
-Tasks with the `will-do-later` tag are intentionally deferred tasks, so skip them. Only select tasks without the `will-do-later` tag.
+Tasks with the `will-do-later` tag are intentionally deferred tasks. Skip them **unless** they are in `ready` status — a task promoted to `ready` is executable regardless of the tag.
 
 **Priority (read from `metadata` field in the list JSON response):**
 ```

--- a/skills/agkan-run/SKILL.md
+++ b/skills/agkan-run/SKILL.md
@@ -48,7 +48,7 @@ agkan task list --status ready --json
 Evaluate tasks in descending order using the following criteria and select the top one:
 
 **Skip tasks with `will-do-later` tag:**
-Tasks with the `will-do-later` tag are intentionally postponed tasks, so skip them. Only select tasks that do not have the `will-do-later` tag.
+Tasks with the `will-do-later` tag are intentionally postponed tasks. Skip them **unless** they are in `ready` status — a task promoted to `ready` is executable regardless of the tag.
 
 **Priority (read from `metadata` field in the list JSON response):**
 ```


### PR DESCRIPTION
## Summary

- Update task selection logic in `agkan-run` and `agkan-run-direct` skills
- Tasks with `will-do-later` tag are now treated as executable when in `ready` status
- `ready` status takes precedence over the `will-do-later` tag as the authoritative signal for executability

## Background

The `will-do-later` tag was designed to signal intentional deferral for backlog tasks. However, once a task is promoted to `ready` status, it should be executable regardless of the tag.

## Changes

- `skills/agkan-run/SKILL.md`
- `skills/agkan-run-direct/SKILL.md`
- `.claude/skills/agkan-run/SKILL.md`
- `.claude/skills/agkan-run-direct/SKILL.md`

## Test plan

- [ ] Verify that a `will-do-later` tagged task in `ready` status is selected for execution
- [ ] Verify that a `will-do-later` tagged task in `backlog` status is still skipped

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)