### PR TITLE
fix: prevent done/review transition without actual code commits

### DIFF
--- a/.claude/skills/agkan-run-direct/SKILL.md
+++ b/.claude/skills/agkan-run-direct/SKILL.md
@@ -114,11 +114,20 @@ agkan task get <id> --json
 If the status is still `in_progress`, determine whether the sub-agent encountered a critical error (git push failure, commit failure, permission error). Check the task body for any recorded error messages.
 
 - **If a critical error occurred**: Do NOT update to `done`. Leave the task as `in_progress` so the issue can be resolved manually.
-- **If no critical error occurred** and implementation succeeded but the sub-agent forgot to update the status, update it manually:
+- **If only task management operations were performed** (comment additions, body updates, discussion — no actual commits): Do NOT update to `done`. Leave the task as `in_progress`.
+- **If implementation succeeded** (at least one `git commit` was made and pushed) but the sub-agent forgot to update the status, verify with `git log --oneline -1` and update manually only if a commit exists:
 
 ```bash
+# Verify a commit was actually made before marking done
+git log --oneline -1
+# Only if a commit is confirmed:
 agkan task update <id> status done
 ```
+
+**The following do NOT qualify as implementation success:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code commits
 
 ### 8. Re-fetch Task List and Continue or End Session
 

--- a/.claude/skills/agkan-run/SKILL.md
+++ b/.claude/skills/agkan-run/SKILL.md
@@ -237,9 +237,26 @@ agkan task meta set <id> pr <PR URL>
 
 ### 8. Update Task to Review
 
-Only execute this step if implementation succeeded — specifically, if git push (Step 5)
-and PR creation (Step 6) both completed without critical errors (permission errors, push
-failures, etc.).
+Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
+
+**Implementation succeeded** means ALL of the following:
+- At least one `git commit` was executed in this session (verify with `git log --oneline -1`)
+- Actual code/file changes were committed (not just task management operations)
+- `git push` completed without errors
+- PR was created or already exists
+
+**The following do NOT count as implementation:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code commits
+
+**Before updating to review, verify a commit was made:**
+
+```bash
+git log --oneline -1
+```
+
+If no commits were made in this session, do NOT update the status to review. Leave the task as `in_progress`.
 
 **If a critical error occurred** (e.g., git push failed, PR creation failed, permission
 denied), do NOT update the status to review. Leave the task as `in_progress` and record
@@ -252,7 +269,9 @@ agkan task update <id> body "<existing body>\n\nError: <error description>"
 # Do NOT run: agkan task update <id> status review
 ```
 
-**If implementation succeeded**, update to review:
+**If only task management operations were performed** (comments, body updates, no commits), do NOT update the status to review. Leave the task as `in_progress`.
+
+**If implementation succeeded** (commits were made and pushed, PR created), update to review:
 
 ```bash
 agkan task update <id> status review
@@ -271,7 +290,9 @@ command.
 
 - Do not mark task as done before PR is merged (mark as done after PR review and merge)
 - **Step 8 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred
+- **Step 8 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, PR creation failure, permission error), keep the task as `in_progress` and record the error
+- If only task management operations were performed (no commits), keep the task as `in_progress`
 """
 )
 ```
@@ -287,11 +308,20 @@ agkan task get <id> --json
 If the status is still `in_progress`, determine whether the sub-agent encountered a critical error (git push failure, PR creation failure, permission error). Check the task body for any recorded error messages.
 
 - **If a critical error occurred**: Do NOT update to `review`. Leave the task as `in_progress` so the issue can be resolved manually.
-- **If no critical error occurred** and implementation succeeded but the sub-agent forgot to update the status, update it manually:
+- **If only task management operations were performed** (comment additions, body updates, discussion — no actual commits): Do NOT update to `review`. Leave the task as `in_progress`.
+- **If implementation succeeded** (at least one `git commit` was made and pushed, PR created) but the sub-agent forgot to update the status, verify with `git log --oneline -1` on the task's branch and update manually only if a commit exists:
 
 ```bash
+# Verify a commit was actually made before marking review
+git log --oneline -1
+# Only if a commit is confirmed:
 agkan task update <id> status review
 ```
+
+**The following do NOT qualify as implementation success:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code commits
 
 ### 8. Handle interruptions, then ALWAYS re-fetch and continue
 

--- a/.claude/skills/agkan-subtask-direct/SKILL.md
+++ b/.claude/skills/agkan-subtask-direct/SKILL.md
@@ -89,7 +89,25 @@ If the code reviewer identifies critical issues, fix them and commit the fixes b
 
 ### 7. Update task to done
 
-Only execute this step if implementation succeeded — specifically, if the commit (Step 5) completed without critical errors (permission errors, push failures, etc.).
+Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
+
+**Implementation succeeded** means ALL of the following:
+- At least one `git commit` was executed in this session (verify with `git log --oneline -1`)
+- Actual code/file changes were committed (not just task management operations)
+- `git push` completed without errors
+
+**The following do NOT count as implementation:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code changes
+
+**Before updating to done, verify a commit was made:**
+
+```bash
+git log --oneline -1
+```
+
+If no commits were made in this session (output is empty or only shows pre-existing commits), do NOT update the status to done. Leave the task as `in_progress`.
 
 **If a critical error occurred** (e.g., git push failed, permission denied, commit failed), do NOT update the status to done. Leave the task as `in_progress` and record the error details in the task body:
 
@@ -100,7 +118,9 @@ agkan task update <id> body "<existing body>\n\nError: <error description>"
 # Do NOT run: agkan task update <id> status done
 ```
 
-**If implementation succeeded**, update to done:
+**If only task management operations were performed** (comments, body updates, no commits), do NOT update the status to done. Leave the task as `in_progress`.
+
+**If implementation succeeded** (commits were made and pushed), update to done:
 
 ```bash
 agkan task update <id> status done
@@ -113,5 +133,7 @@ agkan task update <id> status done
 - Do not create a branch (work directly on the current branch)
 - Do not create a PR
 - **Only update to done if implementation succeeded** — if a critical error occurred, keep the task as `in_progress`
+- **Only update to done if at least one `git commit` was made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, commit failure, permission error), keep the task as `in_progress` and record the error
+- If only task management operations were performed (no commits), keep the task as `in_progress`
 - This skill is used after task selection (task selection is done with the `agkan-run-direct` skill)

--- a/skills/agkan-run-direct/SKILL.md
+++ b/skills/agkan-run-direct/SKILL.md
@@ -66,7 +66,7 @@ If incomplete tasks exist in `blockedBy`, do not select that task; instead, sele
 ### 5. Update Task Status to in_progress
 
 ```bash
-agkan task update <id> --status in_progress
+agkan task update <id> status in_progress
 ```
 
 ### 6. Implementation and Completion
@@ -96,13 +96,7 @@ permission denied, etc.), do NOT update the task status to done. Leave the task 
 `in_progress` and record the error in the task body:
 ```bash
 agkan task get <id> --json
-# Write body to tmp file and update using --file to preserve newlines
-cat > /tmp/agkan_body_$$.md << 'BODY'
-<existing body>
-
-Error: <error description>
-BODY
-agkan task update <id> --file /tmp/agkan_body_$$.md
+agkan task update <id> body "<existing body>\n\nError: <error description>"
 ```
 Only update to done if implementation and all commits/pushes succeeded.
 """
@@ -120,11 +114,20 @@ agkan task get <id> --json
 If the status is still `in_progress`, determine whether the sub-agent encountered a critical error (git push failure, commit failure, permission error). Check the task body for any recorded error messages.
 
 - **If a critical error occurred**: Do NOT update to `done`. Leave the task as `in_progress` so the issue can be resolved manually.
-- **If no critical error occurred** and implementation succeeded but the sub-agent forgot to update the status, update it manually:
+- **If only task management operations were performed** (comment additions, body updates, discussion — no actual commits): Do NOT update to `done`. Leave the task as `in_progress`.
+- **If implementation succeeded** (at least one `git commit` was made and pushed) but the sub-agent forgot to update the status, verify with `git log --oneline -1` and update manually only if a commit exists:
 
 ```bash
-agkan task update <id> --status done
+# Verify a commit was actually made before marking done
+git log --oneline -1
+# Only if a commit is confirmed:
+agkan task update <id> status done
 ```
+
+**The following do NOT qualify as implementation success:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code commits
 
 ### 8. Re-fetch Task List and Continue or End Session
 

--- a/skills/agkan-run/SKILL.md
+++ b/skills/agkan-run/SKILL.md
@@ -74,7 +74,7 @@ If there are incomplete tasks in `blockedBy`, do not select that task. Instead, 
 ### 5. Update task to in_progress
 
 ```bash
-agkan task update <id> --status in_progress
+agkan task update <id> status in_progress
 ```
 
 ### 5a. Inspect task body for existing Branch/PR
@@ -130,7 +130,7 @@ Follow these steps to implement the task:
 ### 1. Update Task to In Progress
 
 ```bash
-agkan task update <id> --status in_progress
+agkan task update <id> status in_progress
 ```
 
 ### 2. Check for Existing Branch/PR
@@ -183,13 +183,8 @@ Then continue to Step 3.
 ```bash
 # First, retrieve the existing body
 agkan task get <id> --json
-# Write body to tmp file and update using --file to preserve newlines
-cat > /tmp/agkan_body_$$.md << 'BODY'
-<existing body>
-
-Branch: <branch-name>
-BODY
-agkan task update <id> --file /tmp/agkan_body_$$.md
+# Then update by concatenating existing body with branch name
+agkan task update <id> body "<existing body>\n\nBranch: <branch-name>"
 # Also store as metadata so the board detail panel can display it
 agkan task meta set <id> branch <branch-name>
 ```
@@ -234,22 +229,34 @@ Otherwise, record the newly created PR URL:
 ```bash
 # First, retrieve the existing body
 agkan task get <id> --json
-# Write body to tmp file and update using --file to preserve newlines
-cat > /tmp/agkan_body_$$.md << 'BODY'
-<existing body>
-
-PR: <PR URL>
-BODY
-agkan task update <id> --file /tmp/agkan_body_$$.md
+# Then update by concatenating existing body with PR URL
+agkan task update <id> body "<existing body>\n\nPR: <PR URL>"
 # Also store as metadata so the board detail panel can display it
 agkan task meta set <id> pr <PR URL>
 ```
 
 ### 8. Update Task to Review
 
-Only execute this step if implementation succeeded — specifically, if git push (Step 5)
-and PR creation (Step 6) both completed without critical errors (permission errors, push
-failures, etc.).
+Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
+
+**Implementation succeeded** means ALL of the following:
+- At least one `git commit` was executed in this session (verify with `git log --oneline -1`)
+- Actual code/file changes were committed (not just task management operations)
+- `git push` completed without errors
+- PR was created or already exists
+
+**The following do NOT count as implementation:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code commits
+
+**Before updating to review, verify a commit was made:**
+
+```bash
+git log --oneline -1
+```
+
+If no commits were made in this session, do NOT update the status to review. Leave the task as `in_progress`.
 
 **If a critical error occurred** (e.g., git push failed, PR creation failed, permission
 denied), do NOT update the status to review. Leave the task as `in_progress` and record
@@ -258,20 +265,16 @@ the error details in the task body:
 ```bash
 # On error: record what went wrong in the task body (optional but recommended)
 agkan task get <id> --json
-# Write body to tmp file and update using --file to preserve newlines
-cat > /tmp/agkan_body_$$.md << 'BODY'
-<existing body>
-
-Error: <error description>
-BODY
-agkan task update <id> --file /tmp/agkan_body_$$.md
-# Do NOT run: agkan task update <id> --status review
+agkan task update <id> body "<existing body>\n\nError: <error description>"
+# Do NOT run: agkan task update <id> status review
 ```
 
-**If implementation succeeded**, update to review:
+**If only task management operations were performed** (comments, body updates, no commits), do NOT update the status to review. Leave the task as `in_progress`.
+
+**If implementation succeeded** (commits were made and pushed, PR created), update to review:
 
 ```bash
-agkan task update <id> --status review
+agkan task update <id> status review
 ```
 
 Confirm the update succeeded:
@@ -287,7 +290,9 @@ command.
 
 - Do not mark task as done before PR is merged (mark as done after PR review and merge)
 - **Step 8 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred
+- **Step 8 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, PR creation failure, permission error), keep the task as `in_progress` and record the error
+- If only task management operations were performed (no commits), keep the task as `in_progress`
 """
 )
 ```
@@ -303,11 +308,20 @@ agkan task get <id> --json
 If the status is still `in_progress`, determine whether the sub-agent encountered a critical error (git push failure, PR creation failure, permission error). Check the task body for any recorded error messages.
 
 - **If a critical error occurred**: Do NOT update to `review`. Leave the task as `in_progress` so the issue can be resolved manually.
-- **If no critical error occurred** and implementation succeeded but the sub-agent forgot to update the status, update it manually:
+- **If only task management operations were performed** (comment additions, body updates, discussion — no actual commits): Do NOT update to `review`. Leave the task as `in_progress`.
+- **If implementation succeeded** (at least one `git commit` was made and pushed, PR created) but the sub-agent forgot to update the status, verify with `git log --oneline -1` on the task's branch and update manually only if a commit exists:
 
 ```bash
-agkan task update <id> --status review
+# Verify a commit was actually made before marking review
+git log --oneline -1
+# Only if a commit is confirmed:
+agkan task update <id> status review
 ```
+
+**The following do NOT qualify as implementation success:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code commits
 
 ### 8. Handle interruptions, then ALWAYS re-fetch and continue
 

--- a/skills/agkan-subtask-direct/SKILL.md
+++ b/skills/agkan-subtask-direct/SKILL.md
@@ -17,7 +17,7 @@ A workflow to directly implement a selected task without creating a branch or PR
 ### 1. Update Task to In Progress
 
 ```bash
-agkan task update <id> --status in_progress
+agkan task update <id> status in_progress
 ```
 
 ### 2. Check for Pre-assigned Branch
@@ -89,27 +89,41 @@ If the code reviewer identifies critical issues, fix them and commit the fixes b
 
 ### 7. Update task to done
 
-Only execute this step if implementation succeeded — specifically, if the commit (Step 5) completed without critical errors (permission errors, push failures, etc.).
+Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
+
+**Implementation succeeded** means ALL of the following:
+- At least one `git commit` was executed in this session (verify with `git log --oneline -1`)
+- Actual code/file changes were committed (not just task management operations)
+- `git push` completed without errors
+
+**The following do NOT count as implementation:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code changes
+
+**Before updating to done, verify a commit was made:**
+
+```bash
+git log --oneline -1
+```
+
+If no commits were made in this session (output is empty or only shows pre-existing commits), do NOT update the status to done. Leave the task as `in_progress`.
 
 **If a critical error occurred** (e.g., git push failed, permission denied, commit failed), do NOT update the status to done. Leave the task as `in_progress` and record the error details in the task body:
 
 ```bash
 # On error: record what went wrong in the task body (optional but recommended)
 agkan task get <id> --json
-# Write body to tmp file and update using --file to preserve newlines
-cat > /tmp/agkan_body_$$.md << 'BODY'
-<existing body>
-
-Error: <error description>
-BODY
-agkan task update <id> --file /tmp/agkan_body_$$.md
-# Do NOT run: agkan task update <id> --status done
+agkan task update <id> body "<existing body>\n\nError: <error description>"
+# Do NOT run: agkan task update <id> status done
 ```
 
-**If implementation succeeded**, update to done:
+**If only task management operations were performed** (comments, body updates, no commits), do NOT update the status to done. Leave the task as `in_progress`.
+
+**If implementation succeeded** (commits were made and pushed), update to done:
 
 ```bash
-agkan task update <id> --status done
+agkan task update <id> status done
 ```
 
 ---
@@ -119,5 +133,7 @@ agkan task update <id> --status done
 - Do not create a branch (work directly on the current branch)
 - Do not create a PR
 - **Only update to done if implementation succeeded** — if a critical error occurred, keep the task as `in_progress`
+- **Only update to done if at least one `git commit` was made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, commit failure, permission error), keep the task as `in_progress` and record the error
+- If only task management operations were performed (no commits), keep the task as `in_progress`
 - This skill is used after task selection (task selection is done with the `agkan-run-direct` skill)


### PR DESCRIPTION
## Summary

- Fixes a bug where tasks could transition to `done`/`review` status when only task management operations (comment additions, body updates) were performed — with no actual `git commit` made
- Adds explicit guard conditions to three skill files: `agkan-subtask-direct`, `agkan-run-direct`, and `agkan-run`
- Defines "implementation succeeded" as requiring at least one `git commit` in the session, not just absence of critical errors

## Root Cause

The previous wording — "implementation succeeded means no critical errors" — was ambiguous. An agent adding a comment via `agkan task comment add` and then finishing the session with no errors would be interpreted as "success", triggering an auto-transition to `done`/`review`.

## Changes

- **`agkan-subtask-direct/SKILL.md`**: Step 7 now explicitly lists what counts and what does NOT count as implementation. Requires `git log --oneline -1` verification before marking done.
- **`agkan-run-direct/SKILL.md`**: Step 7 now blocks done update when no commits exist. Adds the same exclusion list.
- **`agkan-run/SKILL.md`**: Both the embedded sub-agent Step 8 and main-thread Step 7 now require commits before updating to review. Important Notes section updated accordingly.
- Both `.claude/skills/` and `./skills/` directories updated per skills-sync rules.

## Test plan

- [ ] Verify that `agkan-subtask-direct` Step 7 instructions now explicitly exclude comment-only sessions from done transition
- [ ] Verify that `agkan-run-direct` Step 7 instructions require commit verification before marking done
- [ ] Verify that `agkan-run` embedded Step 8 and main Step 7 require commits before marking review
- [ ] Verify `.claude/skills/` and `./skills/` are in sync (diff shows identical files)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)