### PR TITLE
fix: prevent review status when user confirmation is required

### DIFF
--- a/.claude/skills/agkan-run/SKILL.md
+++ b/.claude/skills/agkan-run/SKILL.md
@@ -244,6 +244,7 @@ Only execute this step if implementation succeeded — specifically, if ALL of t
 - Actual code/file changes were committed (not just task management operations)
 - `git push` completed without errors
 - PR was created or already exists
+- No pending user confirmations or interruptions remain
 
 **The following do NOT count as implementation:**
 - `agkan task comment add` (comment additions only)
@@ -269,9 +270,19 @@ agkan task update <id> body "<existing body>\n\nError: <error description>"
 # Do NOT run: agkan task update <id> status review
 ```
 
+**If user confirmation was required / execution was interrupted mid-task** (e.g., permission denied for a file edit, user asked a clarifying question, tool use was blocked, or the skill presented choices to the user), do NOT update the status to `review`. Leave the task as `in_progress`:
+
+```bash
+# When interrupted awaiting user input: do NOT advance to review
+# The task remains in_progress until fully implemented after confirmation
+# Do NOT run: agkan task update <id> status review
+```
+
+`review` status means implementation is **fully complete** — a PR has been successfully created and is awaiting human review. It does **not** mean "paused waiting for user input".
+
 **If only task management operations were performed** (comments, body updates, no commits), do NOT update the status to review. Leave the task as `in_progress`.
 
-**If implementation succeeded** (commits were made and pushed, PR created), update to review:
+**If implementation succeeded** (commits were made and pushed, PR created, no pending confirmations), update to review:
 
 ```bash
 agkan task update <id> status review
@@ -418,3 +429,4 @@ See the canonical definition in `agkan/SKILL.md` (Tag Priority section).
 - If no tasks exist, end the session
 - Do not mark task as done before PR merge (mark as done after PR review and merge)
 - **Never stop mid-workflow due to interruptions** — handle them and resume
+- **`review` status is exclusively for tasks where implementation is fully complete and a PR is awaiting human review** — never set `review` when waiting for user input or when execution was interrupted mid-task

--- a/.claude/skills/agkan-subtask/SKILL.md
+++ b/.claude/skills/agkan-subtask/SKILL.md
@@ -162,7 +162,19 @@ If the code reviewer identifies critical issues, fix them, commit and push the f
 
 ### 9. Update Task to Review
 
-Only execute this step if implementation succeeded — specifically, if git push (Step 5) and PR creation (Step 6) both completed without critical errors (permission errors, push failures, etc.).
+Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
+
+**Implementation succeeded** means ALL of the following:
+- At least one `git commit` was executed in this session
+- Actual code/file changes were committed (not just task management operations)
+- `git push` completed without errors
+- PR was created or already exists
+- No pending user confirmations or interruptions remain
+
+**The following do NOT count as implementation:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code commits
 
 **If a critical error occurred** (e.g., git push failed, PR creation failed, permission denied), do NOT update the status to review. Leave the task as `in_progress` and record the error details in the task body:
 
@@ -172,6 +184,16 @@ agkan task get <id> --json
 agkan task update <id> body "<existing body>\n\nError: <error description>"
 # Do NOT run: agkan task update <id> status review
 ```
+
+**If user confirmation was required / execution was interrupted mid-task** (e.g., permission denied for a file edit, user asked a clarifying question, tool use was blocked, or the skill presented choices to the user), do NOT update the status to `review`. Leave the task as `in_progress`:
+
+```bash
+# When interrupted awaiting user input: do NOT advance to review
+# The task remains in_progress until fully implemented after confirmation
+# Do NOT run: agkan task update <id> status review
+```
+
+`review` status means implementation is **fully complete** — a PR has been successfully created and is awaiting human review. It does **not** mean "paused waiting for user input".
 
 **If implementation succeeded**, update to review:
 
@@ -193,5 +215,8 @@ Verify that the status is `review`. If it is still `in_progress`, retry the upda
 
 - Do not mark task as done before PR is merged (mark as done after PR review and merge)
 - **Step 9 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred
+- **Step 9 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, PR creation failure, permission error), keep the task as `in_progress` and record the error
+- **If user confirmation was required or execution was interrupted mid-task**, keep the task as `in_progress` — do NOT advance to `review`
+- `review` status is exclusively for tasks where implementation is fully complete and a PR is awaiting human review
 - This skill is used after task selection (task selection is done with `agkan-run` skill)

--- a/.claude/skills/execute-subtask/SKILL.md
+++ b/.claude/skills/execute-subtask/SKILL.md
@@ -71,6 +71,16 @@ agkan task update <id> body "<existing body>\n\nPR: <PR URL>"
 
 ### 7. Update Task to Review
 
+Only execute this step if implementation succeeded — specifically, if git push (Step 4) and PR creation (Step 5) both completed without critical errors.
+
+**If a critical error occurred** (e.g., git push failed, PR creation failed, permission denied), do NOT update the status to review. Leave the task as `in_progress`.
+
+**If user confirmation was required / execution was interrupted mid-task** (e.g., permission denied for a file edit, user asked a clarifying question, tool use was blocked), do NOT update the status to `review`. Leave the task as `in_progress`.
+
+`review` status means implementation is **fully complete** — a PR has been successfully created and is awaiting human review. It does **not** mean "paused waiting for user input".
+
+**If implementation succeeded**, update to review:
+
 ```bash
 agkan task update <id> status review
 ```
@@ -80,4 +90,6 @@ agkan task update <id> status review
 ## Important Notes
 
 - Do not mark task as done before PR is merged (mark as done after PR review and merge)
+- **Step 7 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred or if user confirmation is pending
+- **`review` status is exclusively for tasks where implementation is fully complete and a PR is awaiting human review**
 - This skill is used after task selection (task selection is done with `execute-task` skill)

--- a/skills/agkan-run/SKILL.md
+++ b/skills/agkan-run/SKILL.md
@@ -244,6 +244,7 @@ Only execute this step if implementation succeeded — specifically, if ALL of t
 - Actual code/file changes were committed (not just task management operations)
 - `git push` completed without errors
 - PR was created or already exists
+- No pending user confirmations or interruptions remain
 
 **The following do NOT count as implementation:**
 - `agkan task comment add` (comment additions only)
@@ -269,9 +270,19 @@ agkan task update <id> body "<existing body>\n\nError: <error description>"
 # Do NOT run: agkan task update <id> status review
 ```
 
+**If user confirmation was required / execution was interrupted mid-task** (e.g., permission denied for a file edit, user asked a clarifying question, tool use was blocked, or the skill presented choices to the user), do NOT update the status to `review`. Leave the task as `in_progress`:
+
+```bash
+# When interrupted awaiting user input: do NOT advance to review
+# The task remains in_progress until fully implemented after confirmation
+# Do NOT run: agkan task update <id> status review
+```
+
+`review` status means implementation is **fully complete** — a PR has been successfully created and is awaiting human review. It does **not** mean "paused waiting for user input".
+
 **If only task management operations were performed** (comments, body updates, no commits), do NOT update the status to review. Leave the task as `in_progress`.
 
-**If implementation succeeded** (commits were made and pushed, PR created), update to review:
+**If implementation succeeded** (commits were made and pushed, PR created, no pending confirmations), update to review:
 
 ```bash
 agkan task update <id> status review
@@ -418,3 +429,4 @@ See the canonical definition in `agkan/SKILL.md` (Tag Priority section).
 - If no tasks exist, end the session
 - Do not mark task as done before PR merge (mark as done after PR review and merge)
 - **Never stop mid-workflow due to interruptions** — handle them and resume
+- **`review` status is exclusively for tasks where implementation is fully complete and a PR is awaiting human review** — never set `review` when waiting for user input or when execution was interrupted mid-task

--- a/skills/agkan-subtask/SKILL.md
+++ b/skills/agkan-subtask/SKILL.md
@@ -19,7 +19,7 @@ Workflow to implement a selected task on a new branch, create a PR, and move to 
 ### 1. Update Task to In Progress
 
 ```bash
-agkan task update <id> --status in_progress
+agkan task update <id> status in_progress
 ```
 
 ### 2. Check for Existing Branch/PR
@@ -89,13 +89,8 @@ Then continue to Step 3.
 ```bash
 # First, retrieve the existing body
 agkan task get <id> --json
-# Write body to tmp file and update using --file to preserve newlines
-cat > /tmp/agkan_body_$$.md << 'BODY'
-<existing body>
-
-Branch: <branch-name>
-BODY
-agkan task update <id> --file /tmp/agkan_body_$$.md
+# Then update by concatenating existing body with branch name
+agkan task update <id> body "<existing body>\n\nBranch: <branch-name>"
 # Also store as metadata so the board detail panel can display it
 agkan task meta set <id> branch <branch-name>
 ```
@@ -137,13 +132,8 @@ Otherwise, record the newly created PR URL:
 ```bash
 # First, retrieve the existing body
 agkan task get <id> --json
-# Write body to tmp file and update using --file to preserve newlines
-cat > /tmp/agkan_body_$$.md << 'BODY'
-<existing body>
-
-PR: <PR URL>
-BODY
-agkan task update <id> --file /tmp/agkan_body_$$.md
+# Then update by concatenating existing body with PR URL
+agkan task update <id> body "<existing body>\n\nPR: <PR URL>"
 # Also store as metadata so the board detail panel can display it
 agkan task meta set <id> pr <PR URL>
 ```
@@ -172,27 +162,43 @@ If the code reviewer identifies critical issues, fix them, commit and push the f
 
 ### 9. Update Task to Review
 
-Only execute this step if implementation succeeded — specifically, if git push (Step 5) and PR creation (Step 6) both completed without critical errors (permission errors, push failures, etc.).
+Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
+
+**Implementation succeeded** means ALL of the following:
+- At least one `git commit` was executed in this session
+- Actual code/file changes were committed (not just task management operations)
+- `git push` completed without errors
+- PR was created or already exists
+- No pending user confirmations or interruptions remain
+
+**The following do NOT count as implementation:**
+- `agkan task comment add` (comment additions only)
+- `agkan task update --body` / `--file` (body/metadata updates only)
+- Discussion or planning without code commits
 
 **If a critical error occurred** (e.g., git push failed, PR creation failed, permission denied), do NOT update the status to review. Leave the task as `in_progress` and record the error details in the task body:
 
 ```bash
 # On error: record what went wrong in the task body (optional but recommended)
 agkan task get <id> --json
-# Write body to tmp file and update using --file to preserve newlines
-cat > /tmp/agkan_body_$$.md << 'BODY'
-<existing body>
-
-Error: <error description>
-BODY
-agkan task update <id> --file /tmp/agkan_body_$$.md
-# Do NOT run: agkan task update <id> --status review
+agkan task update <id> body "<existing body>\n\nError: <error description>"
+# Do NOT run: agkan task update <id> status review
 ```
+
+**If user confirmation was required / execution was interrupted mid-task** (e.g., permission denied for a file edit, user asked a clarifying question, tool use was blocked, or the skill presented choices to the user), do NOT update the status to `review`. Leave the task as `in_progress`:
+
+```bash
+# When interrupted awaiting user input: do NOT advance to review
+# The task remains in_progress until fully implemented after confirmation
+# Do NOT run: agkan task update <id> status review
+```
+
+`review` status means implementation is **fully complete** — a PR has been successfully created and is awaiting human review. It does **not** mean "paused waiting for user input".
 
 **If implementation succeeded**, update to review:
 
 ```bash
-agkan task update <id> --status review
+agkan task update <id> status review
 ```
 
 Confirm the update succeeded:
@@ -209,5 +215,8 @@ Verify that the status is `review`. If it is still `in_progress`, retry the upda
 
 - Do not mark task as done before PR is merged (mark as done after PR review and merge)
 - **Step 9 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred
+- **Step 9 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, PR creation failure, permission error), keep the task as `in_progress` and record the error
+- **If user confirmation was required or execution was interrupted mid-task**, keep the task as `in_progress` — do NOT advance to `review`
+- `review` status is exclusively for tasks where implementation is fully complete and a PR is awaiting human review
 - This skill is used after task selection (task selection is done with `agkan-run` skill)


### PR DESCRIPTION
## Summary

- Add explicit guard conditions to `agkan-subtask/SKILL.md` Step 9 to prevent `review` status transition when user confirmation is required
- Add same guard to `agkan-run/SKILL.md` Step 8 sub-agent prompt section and Notes
- Add same guard to deprecated `execute-subtask/SKILL.md` Step 7
- Sync all changes to `./skills/` counterparts

## Problem

When a permission error occurs during execution and the skill asks the user for input, the task was incorrectly moved to `review` status, conflating "awaiting user input" with "PR under review".

## Fix

Added explicit documentation that `review` status should ONLY be set when implementation is fully complete and a PR is awaiting human review — not when interrupted mid-execution for user confirmation (permission denied, clarifying questions, tool use blocked).

Closes #49

## Test plan
- [ ] Verify the guard conditions are present in all modified skill files
- [ ] Verify the sync between `.claude/skills/` and `./skills/` is maintained