### PR TITLE
docs(agkan): update task copy command documentation

### DIFF
--- a/.claude/skills/agkan/SKILL.md
+++ b/.claude/skills/agkan/SKILL.md
@@ -77,10 +77,10 @@ agkan task update-parent <id> <parent_id>
 agkan task update-parent <id> null  # Remove parent
 
 # Copy task
-agkan task copy <id>               # タスクをコピーしてbacklogステータスで作成
-agkan task copy <id> -s ready      # ステータスを指定してコピー
-agkan task copy <id> --no-tags     # タグをコピーしない
-agkan task copy <id> --json        # JSON形式で出力
+agkan task copy <id>
+agkan task copy <id> --status ready    # Specify destination status (default: backlog)
+agkan task copy <id> --no-tags         # Do not copy tags
+agkan task copy <id> --json            # Output in JSON format
 
 # Delete task
 agkan task delete <id>

--- a/skills/agkan/SKILL.md
+++ b/skills/agkan/SKILL.md
@@ -77,10 +77,10 @@ agkan task update-parent <id> <parent_id>
 agkan task update-parent <id> null  # Remove parent
 
 # Copy task
-agkan task copy <id>               # タスクをコピーしてbacklogステータスで作成
-agkan task copy <id> -s ready      # ステータスを指定してコピー
-agkan task copy <id> --no-tags     # タグをコピーしない
-agkan task copy <id> --json        # JSON形式で出力
+agkan task copy <id>
+agkan task copy <id> --status ready    # Specify destination status (default: backlog)
+agkan task copy <id> --no-tags         # Do not copy tags
+agkan task copy <id> --json            # Output in JSON format
 
 # Delete task
 agkan task delete <id>


### PR DESCRIPTION
## Summary

- Replace Japanese comments with English in `agkan task copy` documentation section
- Update `-s` shorthand option to `--status` long-form option for consistency with other commands
- Apply changes to both `.claude/skills/agkan/SKILL.md` and `skills/agkan/SKILL.md` (kept in sync per project rules)

## Test plan

- [ ] Verify both SKILL.md files have been updated consistently
- [ ] Verify English comments match the task requirements
- [ ] Verify `--status` option is used instead of `-s` shorthand

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)