### PR TITLE
feat(agkan-review): bundle workflow into review.sh script

### DIFF
--- a/.claude/skills/agkan-review/SKILL.md
+++ b/.claude/skills/agkan-review/SKILL.md
@@ -13,6 +13,38 @@ Workflow to retrieve tasks with Review status in agkan, check the merge/close st
 
 ## Workflow
 
+### Primary: Run the bundled script
+
+Run the bundled `review.sh` script to process all review tasks in one command:
+
+```bash
+bash "$(dirname "$(agkan skill path agkan-review 2>/dev/null || echo "$BASE_DIR")")/review.sh"
+```
+
+The base directory for this skill is provided at session start. Use it to resolve the script path:
+
+```bash
+bash "$BASE_DIR/review.sh"
+```
+
+Where `$BASE_DIR` is the base directory shown at the top of the skill (e.g. `/home/gen/.claude/skills/agkan-review`).
+
+The script:
+1. Fetches all tasks with `--status review`
+2. Extracts the PR URL from each task body (`PR: <URL>`) or metadata (`pr` key)
+3. Calls `gh pr view <URL> --json state,mergedAt` for each PR
+4. Updates task status to `done` (MERGED) or `closed` (CLOSED without merge), skips OPEN
+5. Adds a comment recording the reason and timestamp
+6. Prints a summary: `done: X件, closed: X件, スキップ(OPEN): X件, PR未設定: X件`
+
+To register the script in `.claude/settings.json` to eliminate per-command permission prompts, add the script path to `allowedTools` or the relevant bash allowlist.
+
+---
+
+## Fallback: Manual step-by-step workflow
+
+Use the manual steps below if the script is unavailable or you need to process tasks individually.
+
 ### 1. Retrieve Review tasks
 
 ```bash
@@ -61,21 +93,7 @@ gh pr view <PR URL> --json state,mergedAt
 | `CLOSED` (mergedAt is null) | `closed` | `agkan task update <id> status closed` | Increment `closed_count` |
 | `OPEN` | No change | Skip (still under review) | Increment `skipped_open_count` |
 
-### 6. Display summary after all tasks are processed
-
-After processing all tasks, display a summary of the results:
-
-```
-done: <done_count>件, closed: <closed_count>件, スキップ(OPEN): <skipped_open_count>件, PR未設定: <no_pr_count>件
-```
-
-Example output:
-
-```
-done: 2件, closed: 0件, スキップ(OPEN): 0件, PR未設定: 6件
-```
-
-### 5. Add comment recording the reason for status change
+### 6. Add comment recording the reason for status change
 
 After updating status to `done` or `closed`, record the merge date/time and reason:
 
@@ -90,14 +108,10 @@ Comment format by status:
 | `done` | `Merged at <mergedAt>. PR was merged and task is complete.` |
 | `closed` | `PR was closed without merging. Task moved to closed.` |
 
-Example commands:
+### 7. Display summary after all tasks are processed
 
-```bash
-# When merged
-agkan task comment add <id> "Merged at 2026-03-22T10:00:00Z. PR was merged and task is complete."
-
-# When closed without merge
-agkan task comment add <id> "PR was closed without merging. Task moved to closed."
+```
+done: <done_count>件, closed: <closed_count>件, スキップ(OPEN): <skipped_open_count>件, PR未設定: <no_pr_count>件
 ```
 
 ---

--- a/.claude/skills/agkan-review/review.sh
+++ b/.claude/skills/agkan-review/review.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+done_count=0
+closed_count=0
+skipped_open_count=0
+no_pr_count=0
+
+tasks=$(agkan task list --status review --json)
+task_ids=$(echo "$tasks" | jq -r '.[].id')
+
+if [ -z "$task_ids" ]; then
+  echo "No review tasks found."
+  exit 0
+fi
+
+for id in $task_ids; do
+  task=$(echo "$tasks" | jq -r ".[] | select(.id == $id)")
+  title=$(echo "$task" | jq -r '.title')
+
+  # Extract PR URL from body
+  body=$(echo "$task" | jq -r '.body // ""')
+  pr_url=$(echo "$body" | grep -oP '(?<=PR: )https://\S+' || true)
+
+  # Fallback to metadata
+  if [ -z "$pr_url" ]; then
+    pr_url=$(agkan task meta get "$id" pr 2>/dev/null || true)
+  fi
+
+  if [ -z "$pr_url" ]; then
+    echo "[$id] $title — No PR URL found. Manual verification required."
+    no_pr_count=$((no_pr_count + 1))
+    continue
+  fi
+
+  pr_json=$(gh pr view "$pr_url" --json state,mergedAt 2>/dev/null || true)
+  if [ -z "$pr_json" ]; then
+    echo "[$id] $title — Failed to fetch PR: $pr_url"
+    no_pr_count=$((no_pr_count + 1))
+    continue
+  fi
+
+  state=$(echo "$pr_json" | jq -r '.state')
+  merged_at=$(echo "$pr_json" | jq -r '.mergedAt // empty')
+
+  if [ "$state" = "MERGED" ]; then
+    agkan task update "$id" --status done
+    agkan task comment add "$id" "Merged at ${merged_at}. PR was merged and task is complete."
+    echo "[$id] $title — done (merged at $merged_at)"
+    done_count=$((done_count + 1))
+  elif [ "$state" = "CLOSED" ]; then
+    agkan task update "$id" --status closed
+    agkan task comment add "$id" "PR was closed without merging. Task moved to closed."
+    echo "[$id] $title — closed"
+    closed_count=$((closed_count + 1))
+  else
+    echo "[$id] $title — skipped (OPEN)"
+    skipped_open_count=$((skipped_open_count + 1))
+  fi
+done
+
+echo ""
+echo "done: ${done_count}件, closed: ${closed_count}件, スキップ(OPEN): ${skipped_open_count}件, PR未設定: ${no_pr_count}件"

--- a/skills/agkan-review/SKILL.md
+++ b/skills/agkan-review/SKILL.md
@@ -13,6 +13,38 @@ Workflow to retrieve tasks with Review status in agkan, check the merge/close st
 
 ## Workflow
 
+### Primary: Run the bundled script
+
+Run the bundled `review.sh` script to process all review tasks in one command:
+
+```bash
+bash "$(dirname "$(agkan skill path agkan-review 2>/dev/null || echo "$BASE_DIR")")/review.sh"
+```
+
+The base directory for this skill is provided at session start. Use it to resolve the script path:
+
+```bash
+bash "$BASE_DIR/review.sh"
+```
+
+Where `$BASE_DIR` is the base directory shown at the top of the skill (e.g. `/home/gen/.claude/skills/agkan-review`).
+
+The script:
+1. Fetches all tasks with `--status review`
+2. Extracts the PR URL from each task body (`PR: <URL>`) or metadata (`pr` key)
+3. Calls `gh pr view <URL> --json state,mergedAt` for each PR
+4. Updates task status to `done` (MERGED) or `closed` (CLOSED without merge), skips OPEN
+5. Adds a comment recording the reason and timestamp
+6. Prints a summary: `done: X件, closed: X件, スキップ(OPEN): X件, PR未設定: X件`
+
+To register the script in `.claude/settings.json` to eliminate per-command permission prompts, add the script path to `allowedTools` or the relevant bash allowlist.
+
+---
+
+## Fallback: Manual step-by-step workflow
+
+Use the manual steps below if the script is unavailable or you need to process tasks individually.
+
 ### 1. Retrieve Review tasks
 
 ```bash
@@ -61,21 +93,7 @@ gh pr view <PR URL> --json state,mergedAt
 | `CLOSED` (mergedAt is null) | `closed` | `agkan task update <id> status closed` | Increment `closed_count` |
 | `OPEN` | No change | Skip (still under review) | Increment `skipped_open_count` |
 
-### 6. Display summary after all tasks are processed
-
-After processing all tasks, display a summary of the results:
-
-```
-done: <done_count>件, closed: <closed_count>件, スキップ(OPEN): <skipped_open_count>件, PR未設定: <no_pr_count>件
-```
-
-Example output:
-
-```
-done: 2件, closed: 0件, スキップ(OPEN): 0件, PR未設定: 6件
-```
-
-### 5. Add comment recording the reason for status change
+### 6. Add comment recording the reason for status change
 
 After updating status to `done` or `closed`, record the merge date/time and reason:
 
@@ -90,14 +108,10 @@ Comment format by status:
 | `done` | `Merged at <mergedAt>. PR was merged and task is complete.` |
 | `closed` | `PR was closed without merging. Task moved to closed.` |
 
-Example commands:
+### 7. Display summary after all tasks are processed
 
-```bash
-# When merged
-agkan task comment add <id> "Merged at 2026-03-22T10:00:00Z. PR was merged and task is complete."
-
-# When closed without merge
-agkan task comment add <id> "PR was closed without merging. Task moved to closed."
+```
+done: <done_count>件, closed: <closed_count>件, スキップ(OPEN): <skipped_open_count>件, PR未設定: <no_pr_count>件
 ```
 
 ---

--- a/skills/agkan-review/review.sh
+++ b/skills/agkan-review/review.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+done_count=0
+closed_count=0
+skipped_open_count=0
+no_pr_count=0
+
+tasks=$(agkan task list --status review --json)
+task_ids=$(echo "$tasks" | jq -r '.[].id')
+
+if [ -z "$task_ids" ]; then
+  echo "No review tasks found."
+  exit 0
+fi
+
+for id in $task_ids; do
+  task=$(echo "$tasks" | jq -r ".[] | select(.id == $id)")
+  title=$(echo "$task" | jq -r '.title')
+
+  # Extract PR URL from body
+  body=$(echo "$task" | jq -r '.body // ""')
+  pr_url=$(echo "$body" | grep -oP '(?<=PR: )https://\S+' || true)
+
+  # Fallback to metadata
+  if [ -z "$pr_url" ]; then
+    pr_url=$(agkan task meta get "$id" pr 2>/dev/null || true)
+  fi
+
+  if [ -z "$pr_url" ]; then
+    echo "[$id] $title — No PR URL found. Manual verification required."
+    no_pr_count=$((no_pr_count + 1))
+    continue
+  fi
+
+  pr_json=$(gh pr view "$pr_url" --json state,mergedAt 2>/dev/null || true)
+  if [ -z "$pr_json" ]; then
+    echo "[$id] $title — Failed to fetch PR: $pr_url"
+    no_pr_count=$((no_pr_count + 1))
+    continue
+  fi
+
+  state=$(echo "$pr_json" | jq -r '.state')
+  merged_at=$(echo "$pr_json" | jq -r '.mergedAt // empty')
+
+  if [ "$state" = "MERGED" ]; then
+    agkan task update "$id" --status done
+    agkan task comment add "$id" "Merged at ${merged_at}. PR was merged and task is complete."
+    echo "[$id] $title — done (merged at $merged_at)"
+    done_count=$((done_count + 1))
+  elif [ "$state" = "CLOSED" ]; then
+    agkan task update "$id" --status closed
+    agkan task comment add "$id" "PR was closed without merging. Task moved to closed."
+    echo "[$id] $title — closed"
+    closed_count=$((closed_count + 1))
+  else
+    echo "[$id] $title — skipped (OPEN)"
+    skipped_open_count=$((skipped_open_count + 1))
+  fi
+done
+
+echo ""
+echo "done: ${done_count}件, closed: ${closed_count}件, スキップ(OPEN): ${skipped_open_count}件, PR未設定: ${no_pr_count}件"


### PR DESCRIPTION
## Summary

- Add `review.sh` to `.claude/skills/agkan-review/` and `skills/agkan-review/` that processes all review tasks in a single script execution
- Update `SKILL.md` to invoke the script as the primary entry point; manual step-by-step workflow retained as fallback
- Reduces per-command permission prompts: 17 tasks → 1 script execution

## Changes

- `review.sh`: Fetches review tasks, extracts PR URL from body/metadata, checks PR state via `gh pr view`, updates task status to done/closed, adds comments, prints summary
- `SKILL.md`: Script invocation as primary workflow; manual steps as fallback documentation

Closes https://github.com/gendosu/agkan-skills/issues/63

## Test plan

- [ ] Run `bash $BASE_DIR/review.sh` with review tasks present
- [ ] Verify MERGED tasks move to done with mergedAt comment
- [ ] Verify CLOSED tasks move to closed with appropriate comment
- [ ] Verify OPEN tasks are skipped
- [ ] Verify tasks without PR URL show manual-check message
- [ ] Verify summary line matches expected format

🤖 Generated with [Claude Code](https://claude.com/claude-code)