### PR TITLE
fix(agkan-review): fix jq error by using .tasks[] instead of .[]

### DIFF
--- a/.claude/skills/agkan-review/review.sh
+++ b/.claude/skills/agkan-review/review.sh
@@ -7,7 +7,7 @@ skipped_open_count=0
 no_pr_count=0
 
 tasks=$(agkan task list --status review --json)
-task_ids=$(echo "$tasks" | jq -r '.[].id')
+task_ids=$(echo "$tasks" | jq -r '.tasks[].id')
 
 if [ -z "$task_ids" ]; then
   echo "No review tasks found."
@@ -15,7 +15,7 @@ if [ -z "$task_ids" ]; then
 fi
 
 for id in $task_ids; do
-  task=$(echo "$tasks" | jq -r ".[] | select(.id == $id)")
+  task=$(echo "$tasks" | jq -r ".tasks[] | select(.id == $id)")
   title=$(echo "$task" | jq -r '.title')
 
   # Extract PR URL from body

--- a/skills/agkan-review/review.sh
+++ b/skills/agkan-review/review.sh
@@ -7,7 +7,7 @@ skipped_open_count=0
 no_pr_count=0
 
 tasks=$(agkan task list --status review --json)
-task_ids=$(echo "$tasks" | jq -r '.[].id')
+task_ids=$(echo "$tasks" | jq -r '.tasks[].id')
 
 if [ -z "$task_ids" ]; then
   echo "No review tasks found."
@@ -15,7 +15,7 @@ if [ -z "$task_ids" ]; then
 fi
 
 for id in $task_ids; do
-  task=$(echo "$tasks" | jq -r ".[] | select(.id == $id)")
+  task=$(echo "$tasks" | jq -r ".tasks[] | select(.id == $id)")
   title=$(echo "$task" | jq -r '.title')
 
   # Extract PR URL from body


### PR DESCRIPTION
## Summary

- `agkan task list --status review --json` returns a wrapper object `{ totalCount, filters, tasks }`, not a bare array
- `.[].id` iterated over all values including the numeric `totalCount`, causing `Cannot index number with string "id"` error (exit code 5)
- Fixed by changing `.[].id` → `.tasks[].id` and `.[] | select(...)` → `.tasks[] | select(...)` in both `skills/agkan-review/review.sh` and `.claude/skills/agkan-review/review.sh`

Closes #66

## Test plan

- [x] `agkan task list --status review --json | jq -r '.tasks[].id'` — no error when no review tasks
- [x] `bash skills/agkan-review/review.sh` — outputs "No review tasks found." without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)