### PR TITLE
feat(skills): add checkbox update step to agkan-subtask and agkan-subtask-direct

### DIFF
--- a/.claude/skills/agkan-subtask-direct/SKILL.md
+++ b/.claude/skills/agkan-subtask-direct/SKILL.md
@@ -79,7 +79,7 @@ Fix any errors before proceeding.
 
 ### 5. Commit
 
-> **MANDATORY**: Committing and pushing the implementation is required and MUST NOT be skipped. This step must complete before advancing to Steps 6 and 7. Skipping commit for any reason — including when approaching context limits or after running tests/lint — is forbidden.
+> **MANDATORY**: Committing and pushing the implementation is required and MUST NOT be skipped. This step must complete before advancing to Steps 7 and 8. Skipping commit for any reason — including when approaching context limits or after running tests/lint — is forbidden.
 
 Stage files by specifying them explicitly. Do not use `git add -A` as it risks including unintended files such as `.env` or credentials.
 
@@ -92,13 +92,13 @@ git push -u origin <branch-name-or-current>
 
 > **Note**: Do not use `git add -A` or `git add .`. Files containing `.env`, `credentials.*`, or secrets may be committed unintentionally.
 
-**After push, verify it succeeded before proceeding to Step 6:**
+**After push, verify it succeeded before proceeding to Step 7:**
 
 ```bash
 git ls-remote --heads origin <branch-name-or-current>
 ```
 
-If push failed (empty output or non-zero exit code), record the error in the task body and do NOT proceed to Step 6. Leave the task as `in_progress`.
+If push failed (empty output or non-zero exit code), record the error in the task body and do NOT proceed to Step 7. Leave the task as `in_progress`.
 
 **Recovery: If interrupted during Steps 3–5**
 
@@ -107,7 +107,35 @@ If an error, permission denial, or user interruption occurs during implementatio
 2. Record what happened in the task body
 3. Leave the task as `in_progress` — complete the remaining steps before re-evaluating
 
-### 6. Self-Review
+### 6. Update Checkboxes
+
+If the task body contains `- [ ]` checklist items, update items completed during this implementation.
+
+1. Retrieve the current body:
+
+```bash
+TASK_JSON=$(agkan task get <id> --json)
+CURRENT_BODY=$(echo "$TASK_JSON" | jq -r '.task.body // empty')
+```
+
+2. Check whether the body contains unchecked items. If none found, **skip this step**:
+
+```bash
+echo "$CURRENT_BODY" | grep -q -- '- \[ \]' || echo "No unchecked items — skipping"
+```
+
+3. For each item completed in this implementation, replace its `- [ ]` with `- [x]`. Write the updated body to a temp file and apply:
+
+```bash
+cat > /tmp/agkan_checkbox_$$.md << 'BODY'
+<updated body with completed items marked as - [x]>
+BODY
+agkan task update <id> --file /tmp/agkan_checkbox_$$.md
+```
+
+> Only mark items that were actually completed in this session. Leave pending items as `- [ ]`.
+
+### 7. Self-Review
 
 Before updating the task status, perform a self-review of the implementation using the `superpowers:code-reviewer` sub-agent:
 
@@ -129,13 +157,13 @@ Review the git changes (run `git diff HEAD~1 HEAD` to see them) against the orig
 
 If the code reviewer identifies critical issues, fix them and commit the fixes before proceeding.
 
-### 7. Update task to done
+### 8. Update task to done
 
 Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
 
 > **Scope note**: The interruption guard below applies **only to this status
-> transition decision** — not to Steps 3–5. If a confirmation or interruption
-> occurred during implementation and has since been resolved, complete Steps 3–5
+> transition decision** — not to Steps 3–6. If a confirmation or interruption
+> occurred during implementation and has since been resolved, complete Steps 3–6
 > before evaluating the guard below.
 
 **Implementation succeeded** means ALL of the following:

--- a/.claude/skills/agkan-subtask/SKILL.md
+++ b/.claude/skills/agkan-subtask/SKILL.md
@@ -112,7 +112,7 @@ git ls-remote --heads origin <branch-name>
 
 If push failed (empty output or non-zero exit code), record the error in the task body and do NOT proceed to PR creation. Leave the task as `in_progress`.
 
-**Recovery: If interrupted during Steps 4–8**
+**Recovery: If interrupted during Steps 4–7**
 
 If an error, permission denial, or user interruption occurs during implementation (Step 4), commit/push (Step 5), or PR creation (Step 6):
 1. Do NOT update the task status to `review`
@@ -228,11 +228,11 @@ agkan task update <id> body "<existing body>\n\nError: <error description>"
 # Do NOT run: agkan task update <id> status review
 ```
 
-**If an unresolved interruption remains at this point** (e.g., push or PR creation in Steps 5–6 could not complete, a tool use is still blocked, or the skill is still awaiting user clarification), do NOT update the status to `review`. Leave the task as `in_progress`:
+**If an unresolved interruption remains at this point** (e.g., push or PR creation in Steps 5–7 could not complete, a tool use is still blocked, or the skill is still awaiting user clarification), do NOT update the status to `review`. Leave the task as `in_progress`:
 
 ```bash
 # When an unresolved interruption prevents completion: do NOT advance to review
-# Resolve the interruption, complete Steps 5–6, then re-evaluate
+# Resolve the interruption, complete Steps 5–7, then re-evaluate
 # Do NOT run: agkan task update <id> status review
 ```
 

--- a/.claude/skills/agkan-subtask/SKILL.md
+++ b/.claude/skills/agkan-subtask/SKILL.md
@@ -112,7 +112,7 @@ git ls-remote --heads origin <branch-name>
 
 If push failed (empty output or non-zero exit code), record the error in the task body and do NOT proceed to PR creation. Leave the task as `in_progress`.
 
-**Recovery: If interrupted during Steps 4–7**
+**Recovery: If interrupted during Steps 4–8**
 
 If an error, permission denial, or user interruption occurs during implementation (Step 4), commit/push (Step 5), or PR creation (Step 6):
 1. Do NOT update the task status to `review`
@@ -122,7 +122,7 @@ If an error, permission denial, or user interruption occurs during implementatio
 ### 6. Create PR
 
 > **MANDATORY**: PR creation after a successful push is required and MUST NOT be
-> skipped. This step must complete before advancing to Steps 7 and 8. Skipping PR
+> skipped. This step must complete before advancing to Steps 7 and 9. Skipping PR
 > creation for any reason other than an existing `PR:` label (Case A below) is
 > forbidden — including when approaching context limits.
 
@@ -149,7 +149,35 @@ agkan task update <id> body "<existing body>\n\nPR: <PR URL>"
 agkan task meta set <id> pr <PR URL>
 ```
 
-### 8. Self-Review
+### 8. Update Checkboxes
+
+If the task body contains `- [ ]` checklist items, update items completed during this implementation.
+
+1. Retrieve the current body:
+
+```bash
+TASK_JSON=$(agkan task get <id> --json)
+CURRENT_BODY=$(echo "$TASK_JSON" | jq -r '.task.body // empty')
+```
+
+2. Check whether the body contains unchecked items. If none found, **skip this step**:
+
+```bash
+echo "$CURRENT_BODY" | grep -q -- '- \[ \]' || echo "No unchecked items — skipping"
+```
+
+3. For each item completed in this implementation, replace its `- [ ]` with `- [x]`. Write the updated body to a temp file and apply:
+
+```bash
+cat > /tmp/agkan_checkbox_$$.md << 'BODY'
+<updated body with completed items marked as - [x]>
+BODY
+agkan task update <id> --file /tmp/agkan_checkbox_$$.md
+```
+
+> Only mark items that were actually completed in this session. Leave pending items as `- [ ]`.
+
+### 9. Self-Review
 
 Before updating the task status, perform a self-review of the implementation using the `superpowers:code-reviewer` sub-agent:
 
@@ -171,7 +199,7 @@ Review the git changes (run `git diff origin/<default-branch>...HEAD` to see the
 
 If the code reviewer identifies critical issues, fix them, commit and push the fixes, before proceeding.
 
-### 9. Update Task to Review
+### 10. Update Task to Review
 
 Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
 
@@ -182,8 +210,8 @@ Only execute this step if implementation succeeded — specifically, if ALL of t
 - PR was created or already exists
 
 > **Scope note**: The interruption guard below applies **only to this status
-> transition decision** — not to Steps 4–7. If a confirmation or interruption
-> occurred during implementation and has since been resolved, complete Steps 5–6
+> transition decision** — not to Steps 4–8. If a confirmation or interruption
+> occurred during implementation and has since been resolved, complete Steps 5–7
 > before evaluating the guard below.
 
 **The following do NOT count as implementation:**
@@ -229,8 +257,8 @@ Verify that the status is `review`. If it is still `in_progress`, retry the upda
 ## Important Notes
 
 - Do not mark task as done before PR is merged (mark as done after PR review and merge)
-- **Step 9 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred
-- **Step 9 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
+- **Step 10 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred
+- **Step 10 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, PR creation failure, permission error), keep the task as `in_progress` and record the error
 - **If user confirmation was required or execution was interrupted mid-task**, keep the task as `in_progress` — do NOT advance to `review`
 - `review` status is exclusively for tasks where implementation is fully complete and a PR is awaiting human review

--- a/skills/agkan-subtask-direct/SKILL.md
+++ b/skills/agkan-subtask-direct/SKILL.md
@@ -79,7 +79,7 @@ Fix any errors before proceeding.
 
 ### 5. Commit
 
-> **MANDATORY**: Committing and pushing the implementation is required and MUST NOT be skipped. This step must complete before advancing to Steps 6 and 7. Skipping commit for any reason — including when approaching context limits or after running tests/lint — is forbidden.
+> **MANDATORY**: Committing and pushing the implementation is required and MUST NOT be skipped. This step must complete before advancing to Steps 7 and 8. Skipping commit for any reason — including when approaching context limits or after running tests/lint — is forbidden.
 
 Stage files by specifying them explicitly. Do not use `git add -A` as it risks including unintended files such as `.env` or credentials.
 
@@ -92,13 +92,13 @@ git push -u origin <branch-name-or-current>
 
 > **Note**: Do not use `git add -A` or `git add .`. Files containing `.env`, `credentials.*`, or secrets may be committed unintentionally.
 
-**After push, verify it succeeded before proceeding to Step 6:**
+**After push, verify it succeeded before proceeding to Step 7:**
 
 ```bash
 git ls-remote --heads origin <branch-name-or-current>
 ```
 
-If push failed (empty output or non-zero exit code), record the error in the task body and do NOT proceed to Step 6. Leave the task as `in_progress`.
+If push failed (empty output or non-zero exit code), record the error in the task body and do NOT proceed to Step 7. Leave the task as `in_progress`.
 
 **Recovery: If interrupted during Steps 3–5**
 
@@ -107,7 +107,35 @@ If an error, permission denial, or user interruption occurs during implementatio
 2. Record what happened in the task body
 3. Leave the task as `in_progress` — complete the remaining steps before re-evaluating
 
-### 6. Self-Review
+### 6. Update Checkboxes
+
+If the task body contains `- [ ]` checklist items, update items completed during this implementation.
+
+1. Retrieve the current body:
+
+```bash
+TASK_JSON=$(agkan task get <id> --json)
+CURRENT_BODY=$(echo "$TASK_JSON" | jq -r '.task.body // empty')
+```
+
+2. Check whether the body contains unchecked items. If none found, **skip this step**:
+
+```bash
+echo "$CURRENT_BODY" | grep -q -- '- \[ \]' || echo "No unchecked items — skipping"
+```
+
+3. For each item completed in this implementation, replace its `- [ ]` with `- [x]`. Write the updated body to a temp file and apply:
+
+```bash
+cat > /tmp/agkan_checkbox_$$.md << 'BODY'
+<updated body with completed items marked as - [x]>
+BODY
+agkan task update <id> --file /tmp/agkan_checkbox_$$.md
+```
+
+> Only mark items that were actually completed in this session. Leave pending items as `- [ ]`.
+
+### 7. Self-Review
 
 Before updating the task status, perform a self-review of the implementation using the `superpowers:code-reviewer` sub-agent:
 
@@ -129,13 +157,13 @@ Review the git changes (run `git diff HEAD~1 HEAD` to see them) against the orig
 
 If the code reviewer identifies critical issues, fix them and commit the fixes before proceeding.
 
-### 7. Update task to done
+### 8. Update task to done
 
 Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
 
 > **Scope note**: The interruption guard below applies **only to this status
-> transition decision** — not to Steps 3–5. If a confirmation or interruption
-> occurred during implementation and has since been resolved, complete Steps 3–5
+> transition decision** — not to Steps 3–6. If a confirmation or interruption
+> occurred during implementation and has since been resolved, complete Steps 3–6
 > before evaluating the guard below.
 
 **Implementation succeeded** means ALL of the following:

--- a/skills/agkan-subtask/SKILL.md
+++ b/skills/agkan-subtask/SKILL.md
@@ -112,7 +112,7 @@ git ls-remote --heads origin <branch-name>
 
 If push failed (empty output or non-zero exit code), record the error in the task body and do NOT proceed to PR creation. Leave the task as `in_progress`.
 
-**Recovery: If interrupted during Steps 4–8**
+**Recovery: If interrupted during Steps 4–7**
 
 If an error, permission denial, or user interruption occurs during implementation (Step 4), commit/push (Step 5), or PR creation (Step 6):
 1. Do NOT update the task status to `review`
@@ -228,11 +228,11 @@ agkan task update <id> body "<existing body>\n\nError: <error description>"
 # Do NOT run: agkan task update <id> status review
 ```
 
-**If an unresolved interruption remains at this point** (e.g., push or PR creation in Steps 5–6 could not complete, a tool use is still blocked, or the skill is still awaiting user clarification), do NOT update the status to `review`. Leave the task as `in_progress`:
+**If an unresolved interruption remains at this point** (e.g., push or PR creation in Steps 5–7 could not complete, a tool use is still blocked, or the skill is still awaiting user clarification), do NOT update the status to `review`. Leave the task as `in_progress`:
 
 ```bash
 # When an unresolved interruption prevents completion: do NOT advance to review
-# Resolve the interruption, complete Steps 5–6, then re-evaluate
+# Resolve the interruption, complete Steps 5–7, then re-evaluate
 # Do NOT run: agkan task update <id> status review
 ```
 

--- a/skills/agkan-subtask/SKILL.md
+++ b/skills/agkan-subtask/SKILL.md
@@ -112,7 +112,7 @@ git ls-remote --heads origin <branch-name>
 
 If push failed (empty output or non-zero exit code), record the error in the task body and do NOT proceed to PR creation. Leave the task as `in_progress`.
 
-**Recovery: If interrupted during Steps 4–7**
+**Recovery: If interrupted during Steps 4–8**
 
 If an error, permission denial, or user interruption occurs during implementation (Step 4), commit/push (Step 5), or PR creation (Step 6):
 1. Do NOT update the task status to `review`
@@ -122,7 +122,7 @@ If an error, permission denial, or user interruption occurs during implementatio
 ### 6. Create PR
 
 > **MANDATORY**: PR creation after a successful push is required and MUST NOT be
-> skipped. This step must complete before advancing to Steps 7 and 8. Skipping PR
+> skipped. This step must complete before advancing to Steps 7 and 9. Skipping PR
 > creation for any reason other than an existing `PR:` label (Case A below) is
 > forbidden — including when approaching context limits.
 
@@ -149,7 +149,35 @@ agkan task update <id> body "<existing body>\n\nPR: <PR URL>"
 agkan task meta set <id> pr <PR URL>
 ```
 
-### 8. Self-Review
+### 8. Update Checkboxes
+
+If the task body contains `- [ ]` checklist items, update items completed during this implementation.
+
+1. Retrieve the current body:
+
+```bash
+TASK_JSON=$(agkan task get <id> --json)
+CURRENT_BODY=$(echo "$TASK_JSON" | jq -r '.task.body // empty')
+```
+
+2. Check whether the body contains unchecked items. If none found, **skip this step**:
+
+```bash
+echo "$CURRENT_BODY" | grep -q -- '- \[ \]' || echo "No unchecked items — skipping"
+```
+
+3. For each item completed in this implementation, replace its `- [ ]` with `- [x]`. Write the updated body to a temp file and apply:
+
+```bash
+cat > /tmp/agkan_checkbox_$$.md << 'BODY'
+<updated body with completed items marked as - [x]>
+BODY
+agkan task update <id> --file /tmp/agkan_checkbox_$$.md
+```
+
+> Only mark items that were actually completed in this session. Leave pending items as `- [ ]`.
+
+### 9. Self-Review
 
 Before updating the task status, perform a self-review of the implementation using the `superpowers:code-reviewer` sub-agent:
 
@@ -171,7 +199,7 @@ Review the git changes (run `git diff origin/<default-branch>...HEAD` to see the
 
 If the code reviewer identifies critical issues, fix them, commit and push the fixes, before proceeding.
 
-### 9. Update Task to Review
+### 10. Update Task to Review
 
 Only execute this step if implementation succeeded — specifically, if ALL of the following conditions are met:
 
@@ -182,8 +210,8 @@ Only execute this step if implementation succeeded — specifically, if ALL of t
 - PR was created or already exists
 
 > **Scope note**: The interruption guard below applies **only to this status
-> transition decision** — not to Steps 4–7. If a confirmation or interruption
-> occurred during implementation and has since been resolved, complete Steps 5–6
+> transition decision** — not to Steps 4–8. If a confirmation or interruption
+> occurred during implementation and has since been resolved, complete Steps 5–7
 > before evaluating the guard below.
 
 **The following do NOT count as implementation:**
@@ -229,8 +257,8 @@ Verify that the status is `review`. If it is still `in_progress`, retry the upda
 ## Important Notes
 
 - Do not mark task as done before PR is merged (mark as done after PR review and merge)
-- **Step 9 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred
-- **Step 9 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
+- **Step 10 (status → review) must only be executed when implementation succeeded** — do not update to review if a critical error occurred
+- **Step 10 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, PR creation failure, permission error), keep the task as `in_progress` and record the error
 - **If user confirmation was required or execution was interrupted mid-task**, keep the task as `in_progress` — do NOT advance to `review`
 - `review` status is exclusively for tasks where implementation is fully complete and a PR is awaiting human review


### PR DESCRIPTION
## Summary

- Add **Step 8 (Update Checkboxes)** to `agkan-subtask` — inserted between Step 7 (Add PR Information) and the Self-Review step
- Add **Step 6 (Update Checkboxes)** to `agkan-subtask-direct` — inserted between Step 5 (Commit) and the Self-Review step
- Synced changes to both `.claude/skills/` and `./skills/` directories per skills-sync rules

## Behavior

When a task body contains `- [ ]` checklist items (created by `agkan-planning-subtask`), the new step:
1. Retrieves the current task body
2. Checks for unchecked `- [ ]` items (skips the step if none found)
3. Marks completed items as `- [x]` and updates the task body

## Step numbering corrections

After inserting the checkbox update step, corrected step range references in `agkan-subtask`:
- Recovery section: Steps 4-8 → Steps 4-7 (checkbox update is not part of core implementation recovery)
- Unresolved interruption section: Steps 5-6 → Steps 5-7 (include PR info recording step)

## Affected skill files

- `.claude/skills/agkan-subtask`
- `.claude/skills/agkan-subtask-direct`
- `./skills/agkan-subtask`
- `./skills/agkan-subtask-direct`

Closes #116