### PR TITLE
docs(skills): fix outdated 'metadata' comment in agkan-subtask-direct

### DIFF
--- a/.claude/skills/agkan-subtask-direct/SKILL.md
+++ b/.claude/skills/agkan-subtask-direct/SKILL.md
@@ -86,7 +86,7 @@ Stage files by specifying them explicitly. Do not use `git add -A` as it risks i
 ```bash
 git add <file1> <file2> ...
 git commit -m "<commit message>"
-# If a branch was checked out from metadata, push to it; otherwise push to current branch
+# If a branch was checked out from the task's branch column, push to it; otherwise push to current branch
 git push -u origin <branch-name-or-current>
 ```
 

--- a/skills/agkan-subtask-direct/SKILL.md
+++ b/skills/agkan-subtask-direct/SKILL.md
@@ -86,7 +86,7 @@ Stage files by specifying them explicitly. Do not use `git add -A` as it risks i
 ```bash
 git add <file1> <file2> ...
 git commit -m "<commit message>"
-# If a branch was checked out from metadata, push to it; otherwise push to current branch
+# If a branch was checked out from the task's branch column, push to it; otherwise push to current branch
 git push -u origin <branch-name-or-current>
 ```
 


### PR DESCRIPTION
## Summary

- Fix the comment on line 89 of `agkan-subtask-direct/SKILL.md` which incorrectly said "from metadata"
- Branch is now a first-class column, not stored in metadata
- Applied identical fix to both `skills/` and `.claude/skills/` copies per skills-sync rules

## Changes

Updated comment from:
```bash
# If a branch was checked out from metadata, push to it; otherwise push to current branch
```

To:
```bash
# If a branch was checked out from the task's branch column, push to it; otherwise push to current branch
```

## Files changed
- `skills/agkan-subtask-direct/SKILL.md:89`
- `.claude/skills/agkan-subtask-direct/SKILL.md:89`

Closes #117