### PR TITLE
feat: add config-driven model/effort to agkan-planning, agkan-run, and agkan-run-direct

### DIFF
--- a/.claude/skills/agkan-planning/SKILL.md
+++ b/.claude/skills/agkan-planning/SKILL.md
@@ -16,7 +16,7 @@ A planning workflow that uses agkan to review backlog tasks and make decisions a
 ### 0. Fetch Config
 
 ```bash
-CONFIG=$(agkan config get --json)
+CONFIG=$(agkan config get --json 2>/dev/null || echo '{}')
 PLANNING_MODEL=$(echo "$CONFIG" | jq -r '.config.models.planning.model // "sonnet"')
 PLANNING_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.planning.effort // "medium"')
 ```

--- a/.claude/skills/agkan-planning/SKILL.md
+++ b/.claude/skills/agkan-planning/SKILL.md
@@ -13,6 +13,14 @@ A planning workflow that uses agkan to review backlog tasks and make decisions a
 
 ## Workflow
 
+### 0. Fetch Config
+
+```bash
+CONFIG=$(agkan config get --json)
+PLANNING_MODEL=$(echo "$CONFIG" | jq -r '.config.models.planning.model // "sonnet"')
+PLANNING_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.planning.effort // "medium"')
+```
+
 ### 1. Retrieve Backlog Tasks
 
 ```bash
@@ -30,6 +38,7 @@ Do not use `Skill("agkan-planning-subtask")`. Instead, instruct the sub-agent to
 ```
 Task(
   subagent_type="general-purpose",
+  model="<PLANNING_MODEL>",
   description="Review task #<id>",
   prompt="""
 Please review the following backlog task.
@@ -45,6 +54,12 @@ Read .claude/skills/agkan-planning-subtask/SKILL.md and follow its procedures to
 ## Important Constraint
 Your role is ONLY to review the task and update its status in agkan (e.g., move to ready, decompose, or tag for deferral).
 Do NOT implement the task. Do NOT edit any source code or codebase files.
+
+## Effort / Thoroughness
+Effort level: <PLANNING_EFFORT>
+- low: Quick assessment. Focus on obvious gaps or blockers. Minimal research.
+- medium: Standard review. Check requirements clarity, decomposition needs, and implementation readiness.
+- high: Thorough review. Deep analysis of dependencies, edge cases, and potential risks. Research codebase as needed.
 """
 )
 ```

--- a/.claude/skills/agkan-run-direct/SKILL.md
+++ b/.claude/skills/agkan-run-direct/SKILL.md
@@ -18,7 +18,7 @@ A workflow to select the highest priority ready task from agkan, implement it di
 Retrieve the agkan configuration and extract model/effort settings for the sub-agent:
 
 ```bash
-CONFIG=$(agkan config get --json)
+CONFIG=$(agkan config get --json 2>/dev/null || echo '{}')
 RUN_MODEL=$(echo "$CONFIG" | jq -r '.config.models.run.model // "sonnet"')
 RUN_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.run.effort // "medium"')
 ```

--- a/.claude/skills/agkan-run-direct/SKILL.md
+++ b/.claude/skills/agkan-run-direct/SKILL.md
@@ -13,6 +13,18 @@ A workflow to select the highest priority ready task from agkan, implement it di
 
 ## Workflow
 
+### 0. Fetch Config
+
+Retrieve the agkan configuration and extract model/effort settings for the sub-agent:
+
+```bash
+CONFIG=$(agkan config get --json)
+RUN_MODEL=$(echo "$CONFIG" | jq -r '.config.models.run.model // "sonnet"')
+RUN_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.run.effort // "medium"')
+```
+
+These values are passed to the sub-agent in Step 6.
+
 ### 1. Update Branch
 
 This skill is designed to commit directly to the current branch (default branch or topic branch).
@@ -76,6 +88,7 @@ Use the **Task tool (general-purpose sub-agent)** to implement.
 ```
 Task(
   subagent_type="general-purpose",
+  model="<RUN_MODEL>",
   description="Implement task #<id>",
   prompt="""
 Please implement the following task.
@@ -99,6 +112,12 @@ agkan task get <id> --json
 agkan task update <id> body "<existing body>\n\nError: <error description>"
 ```
 Only update to done if implementation and all commits/pushes succeeded.
+
+## Effort
+Thoroughness level for this session: <RUN_EFFORT>
+- low: Implement quickly with minimal exploration; prefer direct solutions
+- medium: Balance thoroughness with speed; standard implementation quality
+- high: Be thorough; explore edge cases, add tests, review carefully
 """
 )
 ```

--- a/.claude/skills/agkan-run/SKILL.md
+++ b/.claude/skills/agkan-run/SKILL.md
@@ -15,6 +15,14 @@ Standard workflow to pick the highest priority ready task from agkan, implement 
 
 ## Workflow
 
+### 0. Fetch Config
+
+```bash
+CONFIG=$(agkan config get --json)
+RUN_MODEL=$(echo "$CONFIG" | jq -r '.config.models.run.model // "sonnet"')
+RUN_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.run.effort // "medium"')
+```
+
 ### 1. Update branch to latest
 
 Before switching to the default branch, check for uncommitted changes:
@@ -102,6 +110,7 @@ Do not use `Skill("agkan-subtask")`; instead, embed the workflow steps directly 
 ```
 Task(
   subagent_type="general-purpose",
+  model="<RUN_MODEL>",
   description="Implement task #<id>",
   prompt="""
 Please implement the following task.
@@ -327,6 +336,10 @@ command.
 - **Step 8 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, PR creation failure, permission error), keep the task as `in_progress` and record the error
 - If only task management operations were performed (no commits), keep the task as `in_progress`
+
+## Effort
+
+Thoroughness hint: <RUN_EFFORT>
 """
 )
 ```

--- a/.claude/skills/agkan-run/SKILL.md
+++ b/.claude/skills/agkan-run/SKILL.md
@@ -107,6 +107,10 @@ Do not use `Skill("agkan-subtask")`; instead, embed the workflow steps directly 
 > **Why embed steps instead of referencing a file path?**
 > Sub-agents spawned via the Task tool start with a fresh context. When installed as a plugin, the skill files may reside at a path unknown to the sub-agent (e.g., under a plugin cache directory), so instructing the sub-agent to read a relative or installation-specific path is unreliable. Embedding the workflow steps directly in the prompt makes the instructions path-independent.
 
+Before calling Task(), substitute the placeholders with the values fetched in Step 0:
+- Replace `<RUN_MODEL>` with the value of `$RUN_MODEL`
+- Replace `<RUN_EFFORT>` with the value of `$RUN_EFFORT`
+
 ```
 Task(
   subagent_type="general-purpose",

--- a/.claude/skills/agkan-run/SKILL.md
+++ b/.claude/skills/agkan-run/SKILL.md
@@ -18,7 +18,7 @@ Standard workflow to pick the highest priority ready task from agkan, implement 
 ### 0. Fetch Config
 
 ```bash
-CONFIG=$(agkan config get --json)
+CONFIG=$(agkan config get --json 2>/dev/null || echo '{}')
 RUN_MODEL=$(echo "$CONFIG" | jq -r '.config.models.run.model // "sonnet"')
 RUN_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.run.effort // "medium"')
 ```

--- a/skills/agkan-planning/SKILL.md
+++ b/skills/agkan-planning/SKILL.md
@@ -16,7 +16,7 @@ A planning workflow that uses agkan to review backlog tasks and make decisions a
 ### 0. Fetch Config
 
 ```bash
-CONFIG=$(agkan config get --json)
+CONFIG=$(agkan config get --json 2>/dev/null || echo '{}')
 PLANNING_MODEL=$(echo "$CONFIG" | jq -r '.config.models.planning.model // "sonnet"')
 PLANNING_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.planning.effort // "medium"')
 ```

--- a/skills/agkan-planning/SKILL.md
+++ b/skills/agkan-planning/SKILL.md
@@ -13,6 +13,14 @@ A planning workflow that uses agkan to review backlog tasks and make decisions a
 
 ## Workflow
 
+### 0. Fetch Config
+
+```bash
+CONFIG=$(agkan config get --json)
+PLANNING_MODEL=$(echo "$CONFIG" | jq -r '.config.models.planning.model // "sonnet"')
+PLANNING_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.planning.effort // "medium"')
+```
+
 ### 1. Retrieve Backlog Tasks
 
 ```bash
@@ -30,6 +38,7 @@ Do not use `Skill("agkan-planning-subtask")`. Instead, instruct the sub-agent to
 ```
 Task(
   subagent_type="general-purpose",
+  model="<PLANNING_MODEL>",
   description="Review task #<id>",
   prompt="""
 Please review the following backlog task.
@@ -45,6 +54,12 @@ Read .claude/skills/agkan-planning-subtask/SKILL.md and follow its procedures to
 ## Important Constraint
 Your role is ONLY to review the task and update its status in agkan (e.g., move to ready, decompose, or tag for deferral).
 Do NOT implement the task. Do NOT edit any source code or codebase files.
+
+## Effort / Thoroughness
+Effort level: <PLANNING_EFFORT>
+- low: Quick assessment. Focus on obvious gaps or blockers. Minimal research.
+- medium: Standard review. Check requirements clarity, decomposition needs, and implementation readiness.
+- high: Thorough review. Deep analysis of dependencies, edge cases, and potential risks. Research codebase as needed.
 """
 )
 ```

--- a/skills/agkan-run-direct/SKILL.md
+++ b/skills/agkan-run-direct/SKILL.md
@@ -18,7 +18,7 @@ A workflow to select the highest priority ready task from agkan, implement it di
 Retrieve the agkan configuration and extract model/effort settings for the sub-agent:
 
 ```bash
-CONFIG=$(agkan config get --json)
+CONFIG=$(agkan config get --json 2>/dev/null || echo '{}')
 RUN_MODEL=$(echo "$CONFIG" | jq -r '.config.models.run.model // "sonnet"')
 RUN_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.run.effort // "medium"')
 ```

--- a/skills/agkan-run-direct/SKILL.md
+++ b/skills/agkan-run-direct/SKILL.md
@@ -13,6 +13,18 @@ A workflow to select the highest priority ready task from agkan, implement it di
 
 ## Workflow
 
+### 0. Fetch Config
+
+Retrieve the agkan configuration and extract model/effort settings for the sub-agent:
+
+```bash
+CONFIG=$(agkan config get --json)
+RUN_MODEL=$(echo "$CONFIG" | jq -r '.config.models.run.model // "sonnet"')
+RUN_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.run.effort // "medium"')
+```
+
+These values are passed to the sub-agent in Step 6.
+
 ### 1. Update Branch
 
 This skill is designed to commit directly to the current branch (default branch or topic branch).
@@ -76,6 +88,7 @@ Use the **Task tool (general-purpose sub-agent)** to implement.
 ```
 Task(
   subagent_type="general-purpose",
+  model="<RUN_MODEL>",
   description="Implement task #<id>",
   prompt="""
 Please implement the following task.
@@ -99,6 +112,12 @@ agkan task get <id> --json
 agkan task update <id> body "<existing body>\n\nError: <error description>"
 ```
 Only update to done if implementation and all commits/pushes succeeded.
+
+## Effort
+Thoroughness level for this session: <RUN_EFFORT>
+- low: Implement quickly with minimal exploration; prefer direct solutions
+- medium: Balance thoroughness with speed; standard implementation quality
+- high: Be thorough; explore edge cases, add tests, review carefully
 """
 )
 ```

--- a/skills/agkan-run/SKILL.md
+++ b/skills/agkan-run/SKILL.md
@@ -15,6 +15,14 @@ Standard workflow to pick the highest priority ready task from agkan, implement 
 
 ## Workflow
 
+### 0. Fetch Config
+
+```bash
+CONFIG=$(agkan config get --json)
+RUN_MODEL=$(echo "$CONFIG" | jq -r '.config.models.run.model // "sonnet"')
+RUN_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.run.effort // "medium"')
+```
+
 ### 1. Update branch to latest
 
 Before switching to the default branch, check for uncommitted changes:
@@ -102,6 +110,7 @@ Do not use `Skill("agkan-subtask")`; instead, embed the workflow steps directly 
 ```
 Task(
   subagent_type="general-purpose",
+  model="<RUN_MODEL>",
   description="Implement task #<id>",
   prompt="""
 Please implement the following task.
@@ -327,6 +336,10 @@ command.
 - **Step 8 (status → review) requires at least one `git commit` to have been made** — task management operations alone (comments, body updates) do NOT qualify as implementation
 - If a critical error occurs (git push failure, PR creation failure, permission error), keep the task as `in_progress` and record the error
 - If only task management operations were performed (no commits), keep the task as `in_progress`
+
+## Effort
+
+Thoroughness hint: <RUN_EFFORT>
 """
 )
 ```

--- a/skills/agkan-run/SKILL.md
+++ b/skills/agkan-run/SKILL.md
@@ -107,6 +107,10 @@ Do not use `Skill("agkan-subtask")`; instead, embed the workflow steps directly 
 > **Why embed steps instead of referencing a file path?**
 > Sub-agents spawned via the Task tool start with a fresh context. When installed as a plugin, the skill files may reside at a path unknown to the sub-agent (e.g., under a plugin cache directory), so instructing the sub-agent to read a relative or installation-specific path is unreliable. Embedding the workflow steps directly in the prompt makes the instructions path-independent.
 
+Before calling Task(), substitute the placeholders with the values fetched in Step 0:
+- Replace `<RUN_MODEL>` with the value of `$RUN_MODEL`
+- Replace `<RUN_EFFORT>` with the value of `$RUN_EFFORT`
+
 ```
 Task(
   subagent_type="general-purpose",

--- a/skills/agkan-run/SKILL.md
+++ b/skills/agkan-run/SKILL.md
@@ -18,7 +18,7 @@ Standard workflow to pick the highest priority ready task from agkan, implement 
 ### 0. Fetch Config
 
 ```bash
-CONFIG=$(agkan config get --json)
+CONFIG=$(agkan config get --json 2>/dev/null || echo '{}')
 RUN_MODEL=$(echo "$CONFIG" | jq -r '.config.models.run.model // "sonnet"')
 RUN_EFFORT=$(echo "$CONFIG" | jq -r '.config.models.run.effort // "medium"')
 ```


### PR DESCRIPTION
## Summary

Add config-driven model and effort settings to three core skills: `agkan-planning`, `agkan-run`, and `agkan-run-direct`. Skills now fetch `models.planning.model/effort` and `models.run.model/effort` from agkan config and pass them to sub-agents, enabling centralized control over agent selection and thoroughness levels.

## Changes

- **agkan-planning**: Fetch `planning.model` and `planning.effort` from config; pass `model` to planning subtask sub-agent and include effort guidance in prompt
- **agkan-run**: Fetch `run.model` and `run.effort` from config; pass `model` to implementation sub-agent and include effort/thoroughness hint in prompt
- **agkan-run-direct**: Fetch `run.model` and `run.effort` from config; pass `model` and include effort hint in implementation instructions

## Synchronization

Skills are maintained in both `.claude/skills/` and `./skills/` directories per the project's sync rules. Both locations have been updated identically.
