### PR TITLE
chore(git): ignore tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .agkan.yml
+tmp


### PR DESCRIPTION
## Summary

Add `tmp` directory to `.gitignore` to prevent temporary files from being tracked in version control.

## Changes

- Updated `.gitignore` to exclude the `tmp/` directory

This ensures temporary files and directories created during development are not committed to the repository.
