### PR TITLE
fix(agkan-review): replace grep -oP with sed for macOS compatibility

### DIFF
--- a/.claude/skills/agkan-review/SKILL.md
+++ b/.claude/skills/agkan-review/SKILL.md
@@ -153,3 +153,22 @@ Display summary: done: X件, closed: X件, スキップ(OPEN): X件, PR未設定
 - If PR URL is not found in either location, prompt for manual verification (skip task)
 - `done` means successful completion, `closed` means suspended or withdrawn
 - The `gh` command is required and will not work in environments where it is unavailable
+
+---
+
+## Troubleshooting
+
+### `grep: invalid option -- P` on macOS
+
+BSD grep (shipped with macOS) does not support the `-P` (Perl-compatible regex) flag. If you see this error, you are likely running an older version of `review.sh` that used `grep -oP`.
+
+**Symptom:** PR URLs are not extracted from task bodies, and the script silently falls back to metadata lookup (which may also be empty), resulting in `PR未設定` for tasks that do have a `PR: <URL>` line.
+
+**Fix:** The current `review.sh` uses `sed` instead of `grep -oP`:
+
+```bash
+# Compatible with macOS (BSD) and Linux (GNU)
+pr_url=$(echo "$body" | sed -n 's/.*PR: \(https:\/\/[^[:space:]]*\).*/\1/p' | head -1 || true)
+```
+
+If you are still seeing the error after updating, confirm you are running the latest version of the skill.

--- a/.claude/skills/agkan-review/review.sh
+++ b/.claude/skills/agkan-review/review.sh
@@ -20,7 +20,7 @@ for id in $task_ids; do
 
   # Extract PR URL from body
   body=$(echo "$task" | jq -r '.body // ""')
-  pr_url=$(echo "$body" | grep -oP '(?<=PR: )https://\S+' || true)
+  pr_url=$(echo "$body" | sed -n 's/.*PR: \(https:\/\/[^[:space:]]*\).*/\1/p' | head -1 || true)
 
   # Fallback to metadata
   if [ -z "$pr_url" ]; then

--- a/skills/agkan-review/SKILL.md
+++ b/skills/agkan-review/SKILL.md
@@ -153,3 +153,22 @@ Display summary: done: X件, closed: X件, スキップ(OPEN): X件, PR未設定
 - If PR URL is not found in either location, prompt for manual verification (skip task)
 - `done` means successful completion, `closed` means suspended or withdrawn
 - The `gh` command is required and will not work in environments where it is unavailable
+
+---
+
+## Troubleshooting
+
+### `grep: invalid option -- P` on macOS
+
+BSD grep (shipped with macOS) does not support the `-P` (Perl-compatible regex) flag. If you see this error, you are likely running an older version of `review.sh` that used `grep -oP`.
+
+**Symptom:** PR URLs are not extracted from task bodies, and the script silently falls back to metadata lookup (which may also be empty), resulting in `PR未設定` for tasks that do have a `PR: <URL>` line.
+
+**Fix:** The current `review.sh` uses `sed` instead of `grep -oP`:
+
+```bash
+# Compatible with macOS (BSD) and Linux (GNU)
+pr_url=$(echo "$body" | sed -n 's/.*PR: \(https:\/\/[^[:space:]]*\).*/\1/p' | head -1 || true)
+```
+
+If you are still seeing the error after updating, confirm you are running the latest version of the skill.

--- a/skills/agkan-review/review.sh
+++ b/skills/agkan-review/review.sh
@@ -20,7 +20,7 @@ for id in $task_ids; do
 
   # Extract PR URL from body
   body=$(echo "$task" | jq -r '.body // ""')
-  pr_url=$(echo "$body" | grep -oP '(?<=PR: )https://\S+' || true)
+  pr_url=$(echo "$body" | sed -n 's/.*PR: \(https:\/\/[^[:space:]]*\).*/\1/p' | head -1 || true)
 
   # Fallback to metadata
   if [ -z "$pr_url" ]; then


### PR DESCRIPTION
## Summary

- Replace `grep -oP` with `sed` in `review.sh` for macOS (BSD grep) compatibility
- Add `## Troubleshooting` section to `SKILL.md` documenting the `grep: invalid option -- P` error
- Sync both changes to `.claude/skills/agkan-review/` per skills-sync rules

## Background

macOS ships with BSD grep which does not support `-P` (Perl-compatible regex). The original `grep -oP '(?<=PR: )https://\S+'` was silently swallowed by `|| true`, causing PR URLs to not be extracted from task bodies and silently falling back to metadata lookup.

## Changes

- `review.sh` line 23: `grep -oP` → `sed -n 's/.*PR: \(https:\/\/[^[:space:]]*\).*/\1/p' | head -1`
- `SKILL.md`: Added `## Troubleshooting` section explaining the macOS grep issue

## Test plan

- [ ] Run `echo "PR: https://github.com/user/repo/pull/123" | sed -n 's/.*PR: \(https:\/\/[^[:space:]]*\).*/\1/p' | head -1` and confirm URL is extracted correctly
- [ ] Confirm both `skills/agkan-review/` and `.claude/skills/agkan-review/` files are in sync

Closes #126