### PR TITLE
docs(agkan): add agkan config get command to Configuration section

### DIFF
--- a/.claude/skills/agkan/SKILL.md
+++ b/.claude/skills/agkan/SKILL.md
@@ -497,3 +497,17 @@ path: ./.agkan/data.db
 ```
 
 Or use environment variable: `AGENT_KANBAN_DB_PATH=/custom/path/data.db`
+
+### Config Commands
+
+```bash
+# Get all resolved config values from .agkan.yml
+agkan config get
+
+# Get a specific config value (dot notation)
+agkan config get board.port
+agkan config get models.planning.model
+
+# Output in JSON format
+agkan config get --json
+```

--- a/skills/agkan/SKILL.md
+++ b/skills/agkan/SKILL.md
@@ -497,3 +497,17 @@ path: ./.agkan/data.db
 ```
 
 Or use environment variable: `AGENT_KANBAN_DB_PATH=/custom/path/data.db`
+
+### Config Commands
+
+```bash
+# Get all resolved config values from .agkan.yml
+agkan config get
+
+# Get a specific config value (dot notation)
+agkan config get board.port
+agkan config get models.planning.model
+
+# Output in JSON format
+agkan config get --json
+```


### PR DESCRIPTION
## Summary

- Add `agkan config get` command to the Configuration section of `skills/agkan/SKILL.md`
- Sync the same change to `.claude/skills/agkan/SKILL.md` (per skills-sync rules)

## Changes

Added a new "Config Commands" subsection under Configuration with usage examples:
- `agkan config get` - Get all resolved config values
- `agkan config get <key>` - Get a specific value using dot notation
- `agkan config get --json` - Output in JSON format

## Test plan

- [ ] Verify `agkan config get` command works as documented
- [ ] Verify both SKILL.md files are identical (diff should be empty)

Closes #121