### PR TITLE
docs(agkan): document agkan context command and deprecate agent-guide --hook

### DIFF
--- a/.claude/skills/agkan/SKILL.md
+++ b/.claude/skills/agkan/SKILL.md
@@ -22,6 +22,18 @@ description: Use when managing tasks with the agkan CLI tool - creating, listing
 agkan agent-guide
 ```
 
+### Context
+
+```bash
+# Output context for AI agents (used in Claude Code SessionStart hook)
+agkan context
+
+# Output in JSON format (for SessionStart hook integration)
+agkan context --hook
+```
+
+> **Note:** `agkan agent-guide --hook` is **deprecated**. Use `agkan context --hook` instead.
+
 ### Task Operations
 
 ```bash

--- a/skills/agkan/SKILL.md
+++ b/skills/agkan/SKILL.md
@@ -22,6 +22,18 @@ description: Use when managing tasks with the agkan CLI tool - creating, listing
 agkan agent-guide
 ```
 
+### Context
+
+```bash
+# Output context for AI agents (used in Claude Code SessionStart hook)
+agkan context
+
+# Output in JSON format (for SessionStart hook integration)
+agkan context --hook
+```
+
+> **Note:** `agkan agent-guide --hook` is **deprecated**. Use `agkan context --hook` instead.
+
 ### Task Operations
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `agkan context` and `agkan context --hook` commands to Agent Guide section
- Mark `agkan agent-guide --hook` as deprecated, directing users to `agkan context --hook`
- Sync changes to both `skills/agkan/SKILL.md` and `.claude/skills/agkan/SKILL.md`

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)