### PR TITLE
fix: move ready status update after self-review in agkan-planning-subtask

### DIFF
--- a/skills/agkan-planning-subtask/SKILL.md
+++ b/skills/agkan-planning-subtask/SKILL.md
@@ -100,23 +100,48 @@ agkan task add "<sub-task name>" "<details>" --parent <original-id>
 agkan task update <id> --status closed
 ```
 
-### 4. Ready Status Movement Decision
+### 4. Ready/Deferral Decision (Decision Only — Do NOT Execute Yet)
 
-Move to Ready if **all** of the following conditions are met:
+**Decide** the outcome for this task. Do NOT run any `agkan task update` command yet.
 
+**Ready** if all of the following conditions are met:
 - Scope that can be implemented as a single PR
 - Implementation approach is clear
 - No unresolved questions that require user input
 
 Blockers do **not** prevent moving to Ready. If planning is complete and the task would be executable once blockers are resolved, move it to Ready. The blocking relationships registered in Step 2 already capture the dependency — when the blocker task is done, this task can be picked up immediately.
 
-Check blocking relationships (already done in Step 2, but verify if needed):
+**Deferral** if any of the following apply:
+- Low impact on current priorities
+- Resources or information are insufficient
+- The task itself is not yet well-defined enough to implement
 
-```bash
-agkan task block list <id> --json
-```
+Record your decision (Ready or Deferral) and the reasoning. Proceed to Step 5.
 
-When moving a task to Ready, also set the priority at this point:
+---
+
+### 5. Self-Review
+
+Before executing any status change, verify all previous steps are complete:
+
+- [ ] Step 1: Task body is updated with content review and task list
+- [ ] Step 2: Blocking relationships are registered (or confirmed none exist)
+- [ ] Step 3: Decomposition decision is made (split or keep as-is)
+- [ ] Step 4: Decision is recorded (Ready or Deferral) with reasoning
+- [ ] No unresolved questions remain
+- [ ] Task scope matches 1 PR = 1 feature standard
+
+If any item is unchecked, return to that step and complete it before proceeding.
+
+---
+
+### 6. Execute Status Change
+
+Only after all self-review items are checked, execute the status change.
+
+**If Ready:**
+
+Determine priority and run:
 
 ```bash
 agkan task update <id> --status ready --priority <value>
@@ -133,9 +158,7 @@ Priority determination criteria:
 | `medium` | Normal feature additions, improvements (default) |
 | `low` | Nice-to-have, work on if time permits |
 
-### 5. Deferral Decision
-
-For tasks that are "something to do later but not now," attach the `will-do-later` tag and keep it in Backlog:
+**If Deferral:**
 
 ```bash
 # Create the tag if it does not exist
@@ -143,11 +166,6 @@ agkan tag add "will-do-later"
 # Attach the tag to the task
 agkan tag attach <task-id> <tag-id-or-name>
 ```
-
-Deferral criteria:
-- Low impact on current priorities
-- Resources or information are insufficient
-- The task itself is not yet well-defined enough to implement
 
 ---
 


### PR DESCRIPTION
Restructured the workflow so that the actual `agkan task update --status ready` command is executed only after a self-review checklist step, preventing premature status changes.

## Changes
- Renamed Step 4 from "Ready Status Movement Decision" to "Ready/Deferral Decision (Decision Only — Do NOT Execute Yet)" to clarify that this step is decision-only
- Added Step 5 "Self-Review" with a checklist to verify all planning steps are complete before any status change
- Renamed former Step 5 "Deferral Decision" and moved it into Step 6 "Execute Status Change"
- Step 6 now contains both Ready and Deferral execution logic after self-review passes

This ensures no status changes happen prematurely and all planning is properly verified.
