### PR TITLE
fix(agkan-review): use --json for meta get to fix PR URL fallback parsing

### DIFF
--- a/.claude/skills/agkan-review/review.sh
+++ b/.claude/skills/agkan-review/review.sh
@@ -24,7 +24,7 @@ for id in $task_ids; do
 
   # Fallback to metadata
   if [ -z "$pr_url" ]; then
-    pr_url=$(agkan task meta get "$id" pr 2>/dev/null || true)
+    pr_url=$(agkan task meta get "$id" pr --json 2>/dev/null | jq -r '.data.value // empty' 2>/dev/null || true)
   fi
 
   if [ -z "$pr_url" ]; then

--- a/skills/agkan-review/review.sh
+++ b/skills/agkan-review/review.sh
@@ -24,7 +24,7 @@ for id in $task_ids; do
 
   # Fallback to metadata
   if [ -z "$pr_url" ]; then
-    pr_url=$(agkan task meta get "$id" pr 2>/dev/null || true)
+    pr_url=$(agkan task meta get "$id" pr --json 2>/dev/null | jq -r '.data.value // empty' 2>/dev/null || true)
   fi
 
   if [ -z "$pr_url" ]; then


### PR DESCRIPTION
## Summary

The metadata fallback process in `review.sh` was calling `agkan task meta get <id> pr` without `--json`, and the formatted report string returned by the command (`✓ Metadata retrieved\n\nKey: pr\nValue: <url>...`) was being directly assigned to `pr_url`. As a result, `gh pr view "$pr_url"` failed with an invalid URL, and tasks with a PR URL only in metadata (without a `PR: <URL>` entry in the body) were incorrectly reported as "PR not set" even though a valid PR actually existed.

## Changes

Changed to use `agkan task meta get "$id" pr --json` and extract only the PR URL using `jq -r '.data.value // empty'`. Updated both `skills/agkan-review/review.sh` and `.claude/skills/agkan-review/review.sh` (both have identical content).

## Verification

Verified that when the fixed script is run against tasks with a PR URL only in metadata (without a `PR:` line in the body), it correctly determines the GitHub PR status (OPEN/MERGED/CLOSED) and no longer incorrectly classifies them as "PR not set".